### PR TITLE
docs: add README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
-# pi-memctx
+<p align="center">
+  <img src="https://em-content.zobj.net/source/apple/391/card-file-box_1f5c3-fe0f.png" width="120" alt="Card file box emoji" />
+</p>
 
-Automatic memory context injection for [pi coding agent](https://github.com/mariozechner/pi-mono).
+<h1 align="center">pi-memctx</h1>
+
+<p align="center">
+  <strong>Local-first memory context for Pi coding agents.</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/github/stars/weauratech/pi-memctx?style=flat&color=yellow" alt="Stars"></a>
+  <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
+  <a href="package.json"><img src="https://img.shields.io/github/package-json/v/weauratech/pi-memctx?style=flat" alt="Version"></a>
+</p>
+
+<p align="center">
+  <a href="#what-it-does">What it does</a> •
+  <a href="#install">Install</a> •
+  <a href="#setup">Setup</a> •
+  <a href="#tools">Tools</a> •
+  <a href="#commands">Commands</a> •
+  <a href="#development">Development</a>
+</p>
+
+---
+
+Automatic memory context injection for [Pi coding agent](https://github.com/mariozechner/pi-mono).
 
 Load, search, and persist knowledge across sessions using Markdown packs.
 


### PR DESCRIPTION
## Summary

- Add the centered card-file-box hero used by the memory README.
- Add repository badges and quick navigation links.
- Preserve the existing pi-memctx content below the hero.

## Validation

```bash
npm test
```

Result: 80 tests passing, 0 failing.
