### PR TITLE
chore: establish open-source project foundation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Report a reproducible problem with pi-memctx
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Do not include secrets, tokens, private memory-pack content, or sensitive data.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the problem and observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Install with ...
+        2. Run ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - OS:
+        - Node version:
+        - Bun version:
+        - Pi version/commit:
+        - pi-memctx version/commit:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Public-safe logs or screenshots
+      description: Remove secrets and private memory content before sharing.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability or sensitive data exposure
+    url: https://github.com/weauratech/pi-memctx/security/policy
+    about: Please do not report security issues publicly. Follow SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an improvement to pi-memctx
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Do not include secrets or private memory-pack content.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: impact
+    attributes:
+      label: User impact
+      description: Who benefits, and what workflow changes?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,62 @@
+<!--
+Thanks for contributing to pi-memctx.
+
+Before submitting, please read:
+- CONTRIBUTING.md
+- SECURITY.md
+
+Keep pull requests focused, public-safe, and easy to review.
+-->
+
+## Summary
+
+<!-- What changed? Keep this concise. -->
+
+## Motivation
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Related issues or discussions
+
+<!-- Use "Fixes #123", "Relates to #123", or "N/A". -->
+
+## Type of change
+
+- [ ] Documentation
+- [ ] Extension behavior
+- [ ] Memory pack detection
+- [ ] Context injection
+- [ ] Search
+- [ ] Persistence / `memctx_save`
+- [ ] Safety / secret blocking
+- [ ] Tests
+- [ ] CI / tooling
+- [ ] Maintenance or cleanup
+- [ ] Breaking change
+
+## How to test or review
+
+```bash
+npm run ci
+```
+
+<!-- Add manual review steps, screenshots, logs, or examples when useful. -->
+
+## Security and privacy checklist
+
+- [ ] This change is generic and safe for a public repository.
+- [ ] No secrets, credentials, private keys, tokens, passwords, or sensitive payloads were added.
+- [ ] No private company, client, customer, or personal sensitive context was added.
+- [ ] Any security-sensitive concern is documented without exposing exploit details or sensitive data.
+
+## User impact
+
+<!-- Does this affect installation, commands, pack structure, tools, context injection, or saved notes? Write "None" if not applicable. -->
+
+## Breaking changes or migration notes
+
+<!-- Write "None" if not applicable. -->
+
+## Reviewer notes
+
+<!-- Call out risks, trade-offs, or follow-up work. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md — pi-memctx
+
+This repository is a Pi extension package for local-first memory context.
+
+## What to read first
+
+1. `README.md` for product direction and install flow.
+2. `docs/architecture.md` before changing runtime behavior.
+3. `docs/safety.md` before changing persistence, context injection, or secret detection.
+4. `CONTRIBUTING.md` before preparing a pull request.
+
+## Important entrypoints
+
+- Extension runtime: `index.ts`
+- Unit tests: `test/unit.test.ts`
+- E2E test: `test/e2e.ts`
+- Getting started: `docs/getting-started.md`
+- Architecture: `docs/architecture.md`
+- Safety model: `docs/safety.md`
+
+## Required checks
+
+Run before committing:
+
+```bash
+npm run ci
+```
+
+This runs TypeScript typecheck, unit tests, and the generated-pack e2e test.
+
+## Safety rules
+
+Never add secrets, tokens, passwords, private keys, credentials, customer data, production payloads, or private memory-pack content to this repository.
+
+When changing `memctx_save`, preserve or strengthen secret blocking. When changing context injection, keep budgets bounded and make source-of-truth precedence explicit.
+
+## Documentation rule
+
+If behavior changes, update `README.md` or the relevant doc under `docs/`. If contributor expectations change, update `CONTRIBUTING.md` and the PR template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to pi-memctx will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/) where practical.
+
+## [Unreleased]
+
+### Added
+
+- Open-source community health files: contributing guide, security policy, support policy, code of conduct, issue templates, and pull request template.
+- GitHub Actions CI for typecheck, unit tests, and e2e tests.
+- Documentation for getting started, architecture, safety, search, persistence, development, and publishing.
+- Example memory pack and reusable note templates.
+
+### Changed
+
+- E2E test now generates a temporary deterministic memory pack instead of depending on local files.
+- TypeScript typecheck is part of the supported development workflow.
+
+## [0.1.0]
+
+### Added
+
+- Initial Pi extension for automatic memory context injection.
+- `memctx_search` tool with qmd support and grep fallback.
+- `memctx_save` tool with secret-pattern blocking.
+- `/pack` and `/pack-generate` commands.
+- Session handoff capture before compaction.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant Code of Conduct.
+
+## Our pledge
+
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- being respectful and inclusive;
+- accepting constructive feedback;
+- focusing on what is best for the community;
+- showing empathy toward others.
+
+Examples of unacceptable behavior:
+
+- harassment or discriminatory language;
+- trolling, insulting, or derogatory comments;
+- publishing others' private information without permission;
+- any conduct that would reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and may remove, edit, or reject comments, commits, issues, and pull requests that do not align with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to pi-memctx
+
+Thanks for considering a contribution.
+
+pi-memctx is a Pi extension for local-first agent memory. It injects relevant Markdown-pack context into Pi sessions and provides tools to search and safely persist durable learnings.
+
+## Ground rules
+
+- Keep the project generic and reusable.
+- Do not add private company, client, customer, or personal sensitive context.
+- Do not add secrets, tokens, passwords, private keys, credentials, payment data, or sensitive payloads.
+- Prefer small, focused pull requests.
+- Update README or docs when behavior changes.
+- Add or update tests for extension behavior changes.
+
+## Development setup
+
+```bash
+git clone https://github.com/weauratech/pi-memctx.git
+cd pi-memctx
+npm ci
+npm run ci
+```
+
+Useful commands:
+
+```bash
+npm test             # unit tests
+npm run typecheck    # TypeScript typecheck
+npm run test:e2e     # generated-pack integration test
+npm run ci           # all required checks
+```
+
+## Pull request checklist
+
+Before opening a PR, verify:
+
+- [ ] The change is generic and safe for a public repository.
+- [ ] No secrets or sensitive data were added.
+- [ ] Extension behavior changes include tests.
+- [ ] `npm run ci` passes locally.
+- [ ] README or docs were updated if user-facing behavior changed.
+- [ ] Breaking changes include migration notes.
+
+## Commit style
+
+Use concise conventional-style commits when practical:
+
+```txt
+feat: add pack generation command
+fix: avoid saving secret-like content
+docs: document qmd fallback behavior
+```
+
+## Security issues
+
+Do not open public issues for vulnerabilities or accidental sensitive data exposure. Follow `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@
   <a href="#what-it-does">What it does</a> •
   <a href="#install">Install</a> •
   <a href="#setup">Setup</a> •
+  <a href="#context-injection-priority">Context</a> •
   <a href="#tools">Tools</a> •
   <a href="#commands">Commands</a> •
+  <a href="#documentation">Docs</a> •
   <a href="#development">Development</a>
 </p>
 
@@ -170,13 +172,27 @@ npm install -g @tobilu/qmd
 
 Without qmd, search uses keyword grep (still works, just less smart).
 
+## Documentation
+
+- [Getting started](docs/getting-started.md)
+- [Architecture](docs/architecture.md)
+- [Safety](docs/safety.md)
+- [Search](docs/search.md)
+- [Persistence](docs/persistence.md)
+- [Development](docs/development.md)
+- [Publishing](docs/publishing.md)
+
 ## Development
 
 ```bash
-npm install
-bun test test/          # 80 unit tests
-bun run test/e2e.ts     # e2e tests
+npm ci
+npm run typecheck
+npm test
+npm run test:e2e
+npm run ci
 ```
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md) before opening a pull request.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
-# pi-memctx
+<p align="center">
+  <img src="https://em-content.zobj.net/source/apple/391/card-file-box_1f5c3-fe0f.png" width="120" alt="Card file box emoji" />
+</p>
 
-Automatic memory context injection for [pi coding agent](https://github.com/mariozechner/pi-mono).
+<h1 align="center">pi-memctx</h1>
+
+<p align="center">
+  <strong>Local-first memory context for Pi coding agents.</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/github/stars/weauratech/pi-memctx?style=flat&color=yellow" alt="Stars"></a>
+  <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
+  <a href="package.json"><img src="https://img.shields.io/github/package-json/v/weauratech/pi-memctx?style=flat" alt="Version"></a>
+</p>
+
+<p align="center">
+  <a href="#what-it-does">What it does</a> •
+  <a href="#install">Install</a> •
+  <a href="#setup">Setup</a> •
+  <a href="#tools">Tools</a> •
+  <a href="#commands">Commands</a> •
+  <a href="#development">Development</a>
+</p>
+
+---
+
+Automatic memory context injection for [Pi coding agent](https://github.com/mariozechner/pi-mono).
 
 Load, search, and persist knowledge across sessions using Markdown packs.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported versions
+
+The `main` branch is the active development line until the project publishes versioned releases.
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for security vulnerabilities, prompt-injection bypasses, or accidental sensitive data exposure.
+
+Use GitHub private vulnerability reporting if enabled, or contact the maintainers through the repository's security contact once published.
+
+## Sensitive data policy
+
+pi-memctx stores and searches local Markdown memory packs. Those packs must never contain:
+
+- secrets;
+- tokens;
+- passwords;
+- private keys;
+- credentials;
+- full payment card numbers;
+- sensitive customer data;
+- sensitive production payloads;
+- private third-party data that cannot be shared with an agent.
+
+Give the agent the map, not the keys.
+
+## Threat model notes
+
+pi-memctx is local-first and does not require hosted infrastructure, but local files can still influence agent behavior. Treat memory packs as trusted-but-reviewable inputs.
+
+Relevant risks:
+
+- accidental persistence of secrets through `memctx_save`;
+- prompt injection in Markdown files;
+- memory poisoning through incorrect or malicious notes;
+- stale decisions overriding current source-of-truth files;
+- accidental publication of private packs.
+
+Mitigations:
+
+- `memctx_save` blocks common secret patterns;
+- memory remains Markdown and can be reviewed in Git;
+- source-of-truth repository files should win over memory notes;
+- keep private packs outside public repositories unless intentionally sanitized.
+
+## If sensitive data is committed
+
+1. Stop using the exposed secret immediately.
+2. Rotate or revoke it at the source.
+3. Remove it from the repository and history before publishing or distributing.
+4. Document only safe pointers to approved secret stores or procedures.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support
+
+Use GitHub issues for public, non-sensitive support:
+
+- bug reports;
+- feature requests;
+- documentation improvements;
+- reproducible installation problems.
+
+Before opening an issue, please check the README and existing issues.
+
+Do **not** include secrets, tokens, private keys, customer data, sensitive payloads, or private memory-pack content in issues, pull requests, screenshots, or logs.
+
+For security vulnerabilities or accidental sensitive data exposure, follow `SECURITY.md` instead of opening a public issue.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,37 @@
+# Architecture
+
+pi-memctx is a single Pi extension implemented in `index.ts`.
+
+## Runtime flow
+
+```txt
+session_start
+  -> resolve pack directory
+  -> detect active pack
+  -> optionally index with qmd
+
+before_agent_start
+  -> search active pack for prompt-relevant context
+  -> build bounded context block
+  -> append context to the system prompt
+
+memctx_search
+  -> qmd keyword/semantic/deep search when available
+  -> grep-style Markdown fallback when qmd is unavailable
+
+memctx_save
+  -> validate content against secret patterns
+  -> write Markdown note with frontmatter
+  -> update an index when available
+
+session_before_compact
+  -> write a compact handoff action note
+```
+
+## Design principles
+
+- Local-first: no hosted service is required.
+- Markdown-first: memory is reviewable with normal tools.
+- Bounded context: lower-priority sections are trimmed before flooding the prompt.
+- qmd optional: semantic search is an enhancement, not a hard dependency.
+- Source of truth wins: repository files and live system state override memory notes.

--- a/docs/decisions/0001-local-first-memory-context.md
+++ b/docs/decisions/0001-local-first-memory-context.md
@@ -1,0 +1,22 @@
+# Decision 0001 — Local-first memory context
+
+## Status
+
+Accepted.
+
+## Context
+
+Coding agents need durable project memory, but hosted memory services add operational overhead, privacy risk, and vendor lock-in.
+
+## Decision
+
+pi-memctx uses local Markdown packs as the memory source and a Pi extension as the runtime integration.
+
+qmd may be used for semantic/deep search, but it remains optional. Without qmd, pi-memctx falls back to local keyword search.
+
+## Consequences
+
+- Users can inspect, edit, review, and version memory with normal tools.
+- Private packs can remain outside public repositories.
+- Search quality improves with qmd but baseline functionality works without it.
+- Users are responsible for keeping memory packs free of secrets and stale instructions.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,5 @@
+# Decision Records
+
+This directory stores public-safe decisions that affect pi-memctx architecture, contributor expectations, safety posture, or user workflows.
+
+Decision records must not include secrets, private memory-pack content, customer data, or private company context.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,35 @@
+# Development
+
+## Requirements
+
+- Node.js 20+
+- Bun
+- npm
+
+## Setup
+
+```bash
+npm ci
+```
+
+## Checks
+
+```bash
+npm run typecheck
+npm test
+npm run test:e2e
+npm run ci
+```
+
+The e2e test creates a temporary memory pack and does not depend on private local files.
+
+## Project layout
+
+```txt
+index.ts          # Pi extension runtime
+test/unit.test.ts # unit tests
+test/e2e.ts      # generated-pack integration test
+docs/            # user and maintainer docs
+examples/         # public-safe example packs
+templates/        # reusable note templates
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started
+
+pi-memctx is a Pi extension that loads local Markdown memory packs, injects relevant context before the agent acts, and exposes tools for search and safe persistence.
+
+## Install
+
+```bash
+pi install git:github.com/weauratech/pi-memctx
+```
+
+Restart Pi or run `/reload` if your Pi session supports it.
+
+## Pack locations
+
+pi-memctx looks for packs in this order:
+
+1. `MEMCTX_PACKS_PATH`
+2. `<cwd>/.pi/memory-vault/packs/`
+3. `~/.pi/agent/memory-vault/packs/`
+
+## Create a pack
+
+Use `/pack-generate` inside a Pi session:
+
+```txt
+/pack-generate /path/to/repos my-project
+```
+
+Or create folders manually:
+
+```txt
+packs/my-project/
+  00-system/
+  20-context/
+  40-actions/
+  50-decisions/
+  60-observations/
+  70-runbooks/
+  80-sessions/
+```
+
+See `examples/basic-pack/` for a minimal public-safe pack.
+
+## Use a pack
+
+```txt
+/pack
+/pack my-project
+```
+
+Ask the agent to search memory:
+
+```txt
+Use memctx_search to find the deploy runbook.
+```
+
+Ask the agent to save durable memory:
+
+```txt
+Save this as a decision: we use deterministic e2e packs for integration tests.
+```

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,23 @@
+# Persistence
+
+`memctx_save` writes durable notes to the active pack.
+
+## Supported types
+
+- `observation`: discovered fact about code, infra, behavior, or conventions.
+- `decision`: durable technical or architectural decision with rationale.
+- `action`: completed task or notable change.
+- `runbook`: repeatable procedure.
+- `context`: project, stack, or team context.
+
+## Behavior
+
+- Notes are Markdown files with frontmatter.
+- Existing notes with the same slug are appended to instead of overwritten.
+- Action notes include the current date in the filename.
+- Index files are updated when a matching index exists.
+- Common secret patterns are blocked before writing.
+
+## Limitations
+
+Secret detection is defensive, not perfect. Review memory notes before publishing or sharing packs.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,21 @@
+# Publishing
+
+This project is installable directly from GitHub with Pi:
+
+```bash
+pi install git:github.com/weauratech/pi-memctx
+```
+
+Before publishing a release:
+
+1. Run `npm run ci`.
+2. Review `SECURITY.md` and ensure no sensitive data was committed.
+3. Update `CHANGELOG.md`.
+4. Create a version tag, for example `v0.1.1`.
+5. Publish GitHub release notes from the changelog.
+
+Use semantic versioning where practical:
+
+- patch: compatible fixes;
+- minor: compatible features;
+- major: breaking behavior or migration required.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,42 @@
+# Safety
+
+pi-memctx gives agents durable context. Durable context is useful, but it must be treated as trusted, reviewable input rather than unquestionable truth.
+
+## Never save
+
+- secrets;
+- tokens;
+- passwords;
+- private keys;
+- credentials;
+- full payment card numbers;
+- sensitive customer data;
+- sensitive production payloads;
+- private third-party data.
+
+## Allowed memory
+
+Good memory notes include:
+
+- repository maps;
+- architecture decisions;
+- safe commands;
+- development conventions;
+- runbooks;
+- migration notes;
+- public-safe observations.
+
+## Risks
+
+- Secret leakage through saved notes.
+- Prompt injection in Markdown memory files.
+- Memory poisoning through wrong or malicious notes.
+- Stale decisions overriding current source files.
+
+## Rules for agents
+
+- Treat memory as context, not authority.
+- Verify source-of-truth files before destructive or production actions.
+- Do not persist sensitive data.
+- Prefer safe pointers to secret stores over copied credentials.
+- Keep context notes specific, dated, and reviewable.

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,27 @@
+# Search
+
+`memctx_search` searches the active memory pack.
+
+## Modes
+
+- `keyword`: fast default mode.
+- `semantic`: meaning-based search when qmd is installed.
+- `deep`: hybrid/reranked search when qmd is installed.
+
+Without qmd, pi-memctx falls back to local grep-style Markdown search.
+
+## Examples
+
+```txt
+memctx_search(query="deploy rollback", mode="keyword", limit=5)
+memctx_search(query="why did we choose postgres", mode="semantic", limit=5)
+memctx_search(query="incident runbook for queue lag", mode="deep", limit=3)
+```
+
+## qmd
+
+Install qmd if you want semantic/deep search:
+
+```bash
+npm install -g @tobilu/qmd
+```

--- a/examples/basic-pack/00-system/pi-agent/memory-manifest.md
+++ b/examples/basic-pack/00-system/pi-agent/memory-manifest.md
@@ -1,0 +1,11 @@
+---
+type: manifest
+id: manifest.demo
+status: active
+tags:
+  - pack/demo
+---
+
+# Demo Memory Manifest
+
+This public-safe example pack shows the minimum structure pi-memctx can load.

--- a/examples/basic-pack/20-context/project-context.md
+++ b/examples/basic-pack/20-context/project-context.md
@@ -1,0 +1,12 @@
+---
+type: context-pack
+id: context.demo.project
+status: active
+tags:
+  - pack/demo
+  - agent-memory/context-pack
+---
+
+# Demo Project Context
+
+The demo service is a small TypeScript project with automated tests and GitHub Actions CI.

--- a/examples/basic-pack/50-decisions/0001-test-strategy.md
+++ b/examples/basic-pack/50-decisions/0001-test-strategy.md
@@ -1,0 +1,12 @@
+---
+type: decision
+id: decision.demo.test-strategy
+status: accepted
+tags:
+  - pack/demo
+  - agent-memory/decision
+---
+
+# Decision — Test strategy
+
+Use deterministic generated fixtures for e2e tests so contributors do not need private local packs.

--- a/examples/basic-pack/70-runbooks/local-validation.md
+++ b/examples/basic-pack/70-runbooks/local-validation.md
@@ -1,0 +1,18 @@
+---
+type: runbook
+id: runbook.demo.local-validation
+status: active
+tags:
+  - pack/demo
+  - agent-memory/runbook
+---
+
+# Local Validation Runbook
+
+Run:
+
+```bash
+npm run ci
+```
+
+Fix typecheck errors before opening a pull request.

--- a/index.ts
+++ b/index.ts
@@ -22,12 +22,23 @@ import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { StringEnum } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
+
+function StringEnum<T extends readonly string[]>(
+	values: T,
+	options?: { description?: string; default?: T[number] },
+) {
+	return Type.Unsafe<T[number]>({
+		type: "string",
+		enum: values,
+		...(options?.description ? { description: options.description } : {}),
+		...(options?.default ? { default: options.default } : {}),
+	});
+}
 
 /** Max chars for each context section */
 const BUDGET = {
@@ -79,7 +90,7 @@ export function findVaultRoot(startDir: string): string | null {
 		if (fs.existsSync(pkgPath)) {
 			try {
 				const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
-				if (pkg.name === "agent-memory-vault") return dir;
+				if (pkg.name === "pi-memctx" || pkg.name === "agent-memory-vault") return dir;
 			} catch {
 				// not valid JSON, keep searching
 			}
@@ -1014,7 +1025,7 @@ export default function (pi: ExtensionAPI) {
 					qmdEmbed(qmdCollection, activePackPath).catch(() => {});
 				}
 
-				ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "success");
+				ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "info");
 				ctx.ui.setStatus("memctx", `📦 ${activePack}`);
 				return;
 			}
@@ -1038,7 +1049,7 @@ export default function (pi: ExtensionAPI) {
 				qmdEmbed(qmdCollection, activePackPath).catch(() => {});
 			}
 
-			ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "success");
+			ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "info");
 			ctx.ui.setStatus("memctx", `📦 ${activePack}`);
 		},
 	});
@@ -1094,7 +1105,7 @@ export default function (pi: ExtensionAPI) {
 
 			ctx.ui.notify(
 				`memctx: Pack "${slug}" generated with ${filesCreated.length} files from ${scanDir}`,
-				"success",
+				"info",
 			);
 
 			// Auto-switch to the new pack

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
       "devDependencies": {
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*",
-        "@sinclair/typebox": "*"
+        "@sinclair/typebox": "*",
+        "@types/bun": "^1.3.13"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2005,6 +2009,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bun": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.13.tgz",
+      "integrity": "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.13"
+      }
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -2186,6 +2200,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.13.tgz",
+      "integrity": "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,53 @@
 {
   "name": "pi-memctx",
   "version": "0.1.0",
-  "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
-  "keywords": ["pi-package", "pi-coding-agent", "memory", "context-injection", "obsidian"],
+  "description": "Automatic local-first memory context injection for Pi coding agents using Markdown packs.",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "agent-memory",
+    "memory",
+    "context-injection",
+    "local-first",
+    "markdown",
+    "obsidian"
+  ],
   "license": "MIT",
   "type": "module",
   "pi": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-ai": "*",
-    "@sinclair/typebox": "*"
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*",
+    "@types/bun": "^1.3.13"
   },
   "scripts": {
     "test": "bun test test/",
-    "typecheck": "tsc --noEmit"
-  }
+    "test:e2e": "bun run test/e2e.ts",
+    "typecheck": "tsc --noEmit",
+    "ci": "npm run typecheck && npm test && npm run test:e2e"
+  },
+  "homepage": "https://github.com/weauratech/pi-memctx#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/weauratech/pi-memctx.git"
+  },
+  "bugs": {
+    "url": "https://github.com/weauratech/pi-memctx/issues"
+  },
+  "author": "WeAura Tech",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "index.ts",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/templates/pack-notes/action.md
+++ b/templates/pack-notes/action.md
@@ -1,0 +1,17 @@
+---
+type: action
+id: action.<pack>.<date>-<slug>
+title: <Title>
+status: completed
+tags:
+  - pack/<pack>
+  - agent-memory/action
+---
+
+# Action — <Title>
+
+## What changed
+
+## Validation
+
+## Follow-up

--- a/templates/pack-notes/context.md
+++ b/templates/pack-notes/context.md
@@ -1,0 +1,17 @@
+---
+type: context-pack
+id: context.<pack>.<slug>
+title: <Title>
+status: active
+tags:
+  - pack/<pack>
+  - agent-memory/context-pack
+---
+
+# <Title>
+
+## Summary
+
+## Source-of-truth files
+
+## Notes

--- a/templates/pack-notes/decision.md
+++ b/templates/pack-notes/decision.md
@@ -1,0 +1,17 @@
+---
+type: decision
+id: decision.<pack>.<slug>
+title: <Title>
+status: accepted
+tags:
+  - pack/<pack>
+  - agent-memory/decision
+---
+
+# Decision — <Title>
+
+## Context
+
+## Decision
+
+## Consequences

--- a/templates/pack-notes/observation.md
+++ b/templates/pack-notes/observation.md
@@ -1,0 +1,17 @@
+---
+type: observation
+id: observation.<pack>.<slug>
+title: <Title>
+status: active
+tags:
+  - pack/<pack>
+  - agent-memory/observation
+---
+
+# Observation — <Title>
+
+## What was observed
+
+## Evidence
+
+## Source of truth

--- a/templates/pack-notes/runbook.md
+++ b/templates/pack-notes/runbook.md
@@ -1,0 +1,19 @@
+---
+type: runbook
+id: runbook.<pack>.<slug>
+title: <Title>
+status: active
+tags:
+  - pack/<pack>
+  - agent-memory/runbook
+---
+
+# Runbook — <Title>
+
+## Preconditions
+
+## Steps
+
+## Rollback
+
+## Safety notes

--- a/test/e2e.ts
+++ b/test/e2e.ts
@@ -1,16 +1,11 @@
 /**
- * E2E test — simulates pi loading the extension against a real pack.
+ * E2E test — simulates Pi loading pi-memctx against a generated demo pack.
  *
- * Run:   bun run test/e2e.ts
- *
- * This test uses a real pack in packs/ to validate:
- *   1. session_start  → detects pack
- *   2. before_agent_start → injects context
- *   3. memctx_search → finds relevant memories
- *   4. session_before_compact → creates handoff
+ * Run: bun run test:e2e
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 import {
@@ -25,23 +20,35 @@ import {
 } from "../index.js";
 import registerExtension from "../index.js";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const VAULT_ROOT = path.resolve(__dirname, "../../..");
-const PACKS_DIR = path.join(VAULT_ROOT, "packs");
+const TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "pi-memctx-e2e-"));
+const PACKS_DIR = path.join(TMP_ROOT, "packs");
 const PACK_NAME = "demo";
 const PACK_PATH = path.join(PACKS_DIR, PACK_NAME);
 
+function write(rel: string, content: string) {
+	const file = path.join(PACK_PATH, rel);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content, "utf-8");
+}
+
+function createDemoPack() {
+	fs.writeFileSync(path.join(TMP_ROOT, "package.json"), JSON.stringify({ name: "pi-memctx" }));
+	write("00-system/pi-agent/memory-manifest.md", "# Demo Memory Manifest\n\nUse this pack for the demo service.\n");
+	write("00-system/indexes/context-index.md", "# Context Index\n\n| Note | Use |\n|---|---|\n| [[packs/demo/20-context/context-pack|Context]] | Demo context |\n");
+	write("20-context/context-pack.md", "# Demo Context\n\nThe demo service uses Go 1.25, PostgreSQL, Redis, and GitHub Actions.\n");
+	write("40-actions/2026-04-30-ci-setup.md", "# Action — CI setup\n\nGitHub Actions validates tests before release.\n");
+	write("50-decisions/0001-api-style.md", "# Decision — API style\n\nUse REST handlers with clear request validation and idempotent webhook processing. Authentication uses ORY Kratos.\n");
+	write("70-runbooks/deploy.md", "# Deploy Runbook\n\nDeploy production with `make deploy-prod` after tests pass. Roll back with `make rollback-prod`.\n");
+}
+
 function createMockPi() {
 	const tools: Record<string, any> = {};
-	const hooks: Record<string, (...args: unknown[]) => unknown> = {};
+	const hooks: Record<string, (...args: any[]) => unknown> = {};
 	const commands: Record<string, any> = {};
 	return {
 		pi: {
 			registerTool(def: any) { tools[def.name] = def; },
-			on(event: string, handler: (...args: unknown[]) => unknown) { hooks[event] = handler; },
+			on(event: string, handler: (...args: any[]) => unknown) { hooks[event] = handler; },
 			registerCommand(name: string, def: any) { commands[name] = def; },
 		},
 		tools,
@@ -64,106 +71,63 @@ function assert(condition: boolean, name: string, detail = "") {
 	else fail(name, detail || "assertion failed");
 }
 
-// ---------------------------------------------------------------------------
-// Run
-// ---------------------------------------------------------------------------
-
 async function main() {
-	console.log("\n🧪 Pi Memory Context — E2E Test\n");
-	console.log(`Vault root: ${VAULT_ROOT}`);
+	createDemoPack();
+
+	console.log("\n🧪 pi-memctx — E2E Test\n");
+	console.log(`Vault root: ${TMP_ROOT}`);
 	console.log(`Pack: ${PACK_NAME} (${PACK_PATH})\n`);
 
-	// Pre-check: pack exists
-	if (!fs.existsSync(PACK_PATH)) {
-		console.error("❌ Pack not found.");
-		process.exit(1);
-	}
-
-	// -----------------------------------------------------------------------
-	// TEST 1: Vault discovery
-	// -----------------------------------------------------------------------
 	console.log("── 1. Vault Discovery ──");
-
 	const foundRoot = findVaultRoot(PACK_PATH);
-	assert(foundRoot === VAULT_ROOT, "findVaultRoot finds vault from pack subdir", `got: ${foundRoot}`);
+	assert(foundRoot === TMP_ROOT, "findVaultRoot finds generated package root", `got: ${foundRoot}`);
 
 	const foundPack = detectActivePack(PACKS_DIR);
-	assert(foundPack !== null, `detectActivePack finds a pack (got: ${foundPack})`);
+	assert(foundPack === PACK_NAME, `detectActivePack finds generated pack (got: ${foundPack})`);
 
 	const packFiles = scanPackFiles(PACK_PATH);
-	assert(packFiles.length >= 10, `scanPackFiles finds ${packFiles.length} markdown files (≥10 expected)`);
+	assert(packFiles.length >= 5, `scanPackFiles finds ${packFiles.length} markdown files (≥5 expected)`);
 
-	// -----------------------------------------------------------------------
-	// TEST 2: Pack context building
-	// -----------------------------------------------------------------------
 	console.log("\n── 2. Pack Context Building ──");
-
 	const context = buildPackContext(PACK_PATH);
-	assert(context.length > 0, "buildPackContext returns non-empty context");
-	assert(context.includes("Go 1.25") || context.includes("Go"), "Context includes stack info (Go)");
-	assert(context.includes("PostgreSQL"), "Context includes database (PostgreSQL)");
-	assert(context.includes("ORY") || context.includes("Chi") || context.includes("Hexagonal"), "Context includes a decision");
-	assert(context.includes("NATS") || context.includes("MCP") || context.includes("ArgoCD"), "Context includes architecture decision");
-	assert(context.includes("GitHub Actions") || context.includes("gitlab-ci") || context.includes("CI"), "Context includes CI action or context");
-	assert(context.includes("Deploy") || context.includes("Terraform"), "Context includes runbook");
-	assert(context.includes("Pack System"), "Context has manifest section header");
-	assert(context.includes("Context Packs"), "Context has context section header");
-	assert(
-		context.includes("Active Decisions") || context.includes("Decisions") || context.length > 0,
-		"Context has decisions section or content",
-	);
-	// Actions section only present if 40-actions has files
-	const hasActions = fs.existsSync(path.join(PACK_PATH, "40-actions")) &&
-		fs.readdirSync(path.join(PACK_PATH, "40-actions")).filter(f => f.endsWith(".md")).length > 0;
-	if (hasActions) {
-		assert(context.includes("Recent Actions"), "Context has actions section header");
-	} else {
-		pass("Context skips empty actions section (no files)");
-	}
-	assert(
-		context.includes("Runbooks") || context.length > 0,
-		"Context has runbooks section or content",
-	);
+	assert(context.includes("Demo Memory Manifest"), "Context includes manifest");
+	assert(context.includes("Go 1.25"), "Context includes stack info");
+	assert(context.includes("PostgreSQL"), "Context includes database info");
+	assert(context.includes("ORY Kratos"), "Context includes decision info");
+	assert(context.includes("Deploy Runbook"), "Context includes runbook");
 	assert(context.length <= 16500, `Context within budget (${context.length} chars ≤ 16500)`);
 
-	// With search results
-	const contextWithSearch = buildPackContext(PACK_PATH, "Found: NATS JetStream config in events module");
+	const contextWithSearch = buildPackContext(PACK_PATH, "Found: PostgreSQL deploy runbook");
 	assert(contextWithSearch.includes("Relevant Memory"), "Context with search includes search header");
-	assert(contextWithSearch.includes("NATS JetStream"), "Context with search includes search result text");
+	assert(contextWithSearch.includes("PostgreSQL deploy"), "Context with search includes search result text");
 
-	// -----------------------------------------------------------------------
-	// TEST 3: Extension hooks registration
-	// -----------------------------------------------------------------------
 	console.log("\n── 3. Extension Registration ──");
-
 	_resetState();
-	const { pi, tools, hooks } = createMockPi();
+	const { pi, tools, hooks, commands } = createMockPi();
 	registerExtension(pi as any);
 
-	assert(!!tools["memctx_search"], "memctx_search tool registered");
-	assert(!!hooks["session_start"], "session_start hook registered");
-	assert(!!hooks["before_agent_start"], "before_agent_start hook registered");
-	assert(!!hooks["session_before_compact"], "session_before_compact hook registered");
-	assert(!!hooks["session_shutdown"], "session_shutdown hook registered");
+	assert(!!tools.memctx_search, "memctx_search tool registered");
+	assert(!!tools.memctx_save, "memctx_save tool registered");
+	assert(!!commands.pack, "/pack command registered");
+	assert(!!commands["pack-generate"], "/pack-generate command registered");
+	assert(!!hooks.session_start, "session_start hook registered");
+	assert(!!hooks.before_agent_start, "before_agent_start hook registered");
+	assert(!!hooks.session_before_compact, "session_before_compact hook registered");
+	assert(!!hooks.session_shutdown, "session_shutdown hook registered");
 
-	// -----------------------------------------------------------------------
-	// TEST 4: before_agent_start injection
-	// -----------------------------------------------------------------------
-	console.log("\n── 4. Context Injection (before_agent_start) ──");
-
-	_setVaultRoot(VAULT_ROOT);
+	console.log("\n── 4. Context Injection ──");
+	_setVaultRoot(TMP_ROOT);
 	_setActivePack(PACK_NAME, PACK_PATH);
 	_setQmdAvailable(false);
 
-	// Re-register with state set
 	const { pi: pi2, tools: tools2, hooks: hooks2 } = createMockPi();
 	registerExtension(pi2 as any);
+	_setVaultRoot(TMP_ROOT);
 	_setActivePack(PACK_NAME, PACK_PATH);
 	_setQmdAvailable(false);
 
 	const basePrompt = "You are a helpful coding assistant.";
-
-	const injectionResult = await hooks2["before_agent_start"](
+	const injectionResult = await hooks2.before_agent_start(
 		{ prompt: "how do we deploy to production?", systemPrompt: basePrompt },
 		{ sessionManager: { getSessionId: () => "e2e-test" }, hasUI: false, ui: {} },
 	) as any;
@@ -172,126 +136,87 @@ async function main() {
 	assert(injectionResult.systemPrompt.startsWith(basePrompt), "Preserves original system prompt");
 	assert(injectionResult.systemPrompt.includes("Memory Context"), "Injects memctx header");
 	assert(injectionResult.systemPrompt.includes(PACK_NAME), "Injects active pack name");
-	assert(injectionResult.systemPrompt.includes("Deploy") || injectionResult.systemPrompt.includes("Terraform"), "Injects relevant runbook");
-	assert(injectionResult.systemPrompt.includes("Go 1.25") || injectionResult.systemPrompt.includes("Go"), "Injects stack context");
+	assert(injectionResult.systemPrompt.includes("Deploy Runbook"), "Injects relevant runbook");
 	assert(injectionResult.systemPrompt.includes("memctx_search"), "Hints about memctx_search tool");
 
-	console.log(`\n  📏 Injected prompt size: ${injectionResult.systemPrompt.length} chars`);
-	console.log(`  📏 Base prompt: ${basePrompt.length} chars`);
-	console.log(`  📏 Injected context: ${injectionResult.systemPrompt.length - basePrompt.length} chars`);
-
-	// -----------------------------------------------------------------------
-	// TEST 5: memctx_search tool (grep fallback)
-	// -----------------------------------------------------------------------
 	console.log("\n── 5. memctx_search Tool ──");
-
-	// Search for database
-	const searchDb = await tools2["memctx_search"].execute(
-		"e2e-1", { query: "PostgreSQL database pgvector" }, null, () => {}, {},
+	const searchDb = await tools2.memctx_search.execute(
+		"e2e-1", { query: "PostgreSQL database" }, null, () => {}, {},
 	);
-	assert(searchDb.content[0].text.includes("PostgreSQL"), "Search 'PostgreSQL database' finds match");
-	assert(searchDb.details.mode === "grep-fallback", "Uses grep-fallback mode (no qmd)");
+	assert(searchDb.content[0].text.includes("PostgreSQL"), "Search finds database context");
+	assert(searchDb.details.mode === "grep-fallback", "Uses grep fallback when qmd is unavailable");
 
-	// Search for deploy
-	const searchDeploy = await tools2["memctx_search"].execute(
-		"e2e-2", { query: "deploy production ArgoCD" }, null, () => {}, {},
+	const searchDeploy = await tools2.memctx_search.execute(
+		"e2e-2", { query: "deploy production" }, null, () => {}, {},
 	);
-	assert(searchDeploy.content[0].text.includes("ArgoCD") || searchDeploy.content[0].text.includes("deploy"), "Search 'deploy production ArgoCD' finds match");
+	assert(searchDeploy.content[0].text.includes("Deploy") || searchDeploy.content[0].text.includes("deploy"), "Search finds deploy context");
 
-	// Search for NATS events
-	const searchNats = await tools2["memctx_search"].execute(
-		"e2e-3", { query: "ORY Kratos authentication" }, null, () => {}, {},
+	const searchNone = await tools2.memctx_search.execute(
+		"e2e-3", { query: "xyznonexistentterm" }, null, () => {}, {},
 	);
-	assert(searchNats.content[0].text.includes("ORY") || searchNats.content[0].text.includes("Kratos"), "Search 'ORY Kratos authentication' finds match");
+	assert(searchNone.content[0].text.includes("No results"), "Search for nonexistent term returns no results");
 
-	// Search with no results
-	const searchNone = await tools2["memctx_search"].execute(
-		"e2e-4", { query: "xyznonexistentterm" }, null, () => {}, {},
+	console.log("\n── 6. memctx_save Tool ──");
+	const saveResult = await tools2.memctx_save.execute(
+		"e2e-4",
+		{
+			type: "decision",
+			title: "Use deterministic e2e packs",
+			content: "E2E tests should generate temporary memory packs instead of depending on local files.",
+			tags: ["testing"],
+		},
+		null,
+		() => {},
+		{},
 	);
-	assert(searchNone.content[0].text.includes("No results"), "Search for nonexistent term returns 'No results'");
+	assert(saveResult.content[0].text.includes("Saved decision"), "memctx_save creates decision note");
+	assert(fs.existsSync(path.join(PACK_PATH, "50-decisions", "use-deterministic-e2e-packs.md")), "Saved decision file exists");
 
-	// Search with limit
-	const searchLimit = await tools2["memctx_search"].execute(
-		"e2e-5", { query: "demo", limit: 2 }, null, () => {}, {},
+	const blockedSave = await tools2.memctx_save.execute(
+		"e2e-5",
+		{ type: "observation", title: "Bad secret", content: "api_key = abc123", tags: [] },
+		null,
+		() => {},
+		{},
 	);
-	const matchHeaders = (searchLimit.content[0].text.match(/### /g) || []).length;
-	assert(matchHeaders <= 2, `Search with limit=2 returns ≤2 results (got ${matchHeaders})`);
+	assert(blockedSave.isError === true, "memctx_save blocks secret-looking content");
 
-	// -----------------------------------------------------------------------
-	// TEST 6: session_before_compact handoff
-	// -----------------------------------------------------------------------
-	console.log("\n── 6. Session Handoff (session_before_compact) ──");
-
-	const handoffSessionId = "e2e-handoff-session-12345678";
-	const compactCtx = {
+	console.log("\n── 7. Session Handoff ──");
+	const actionsDir = path.join(PACK_PATH, "40-actions");
+	const filesBefore = fs.readdirSync(actionsDir);
+	await hooks2.session_before_compact({}, {
 		sessionManager: {
-			getSessionId: () => handoffSessionId,
+			getSessionId: () => "e2e-handoff-session-12345678",
 			getBranch: () => [
 				{ type: "message", message: { role: "user", content: "How do I deploy to staging?" } },
-				{ type: "message", message: { role: "assistant", content: "Run `make deploy-staging` after ensuring tests pass. See the deploy runbook." } },
-				{ type: "message", message: { role: "user", content: "What about rollback?" } },
-				{ type: "message", message: { role: "assistant", content: "Use `kubectl rollout undo deployment/my-app -n my-staging`." } },
+				{ type: "message", message: { role: "assistant", content: "Run deploy staging and use rollback if needed." } },
 			],
 		},
 		hasUI: false,
 		ui: { notify: () => {}, setStatus: () => {} },
-	};
-
-	const actionsDir = path.join(PACK_PATH, "40-actions");
-	const filesBefore = fs.readdirSync(actionsDir);
-	await hooks2["session_before_compact"]({}, compactCtx);
+	});
 	const filesAfter = fs.readdirSync(actionsDir);
-
 	const newFiles = filesAfter.filter((f) => !filesBefore.includes(f));
 	assert(newFiles.length === 1, `Created 1 handoff file (got ${newFiles.length})`);
-
-	const handoffFile = newFiles[0];
-	assert(handoffFile.includes("session-handoff"), `Handoff filename contains 'session-handoff': ${handoffFile}`);
-
-	const handoffContent = fs.readFileSync(path.join(actionsDir, handoffFile), "utf-8");
-	assert(handoffContent.includes("type: action"), "Handoff has type: action frontmatter");
+	const handoffContent = fs.readFileSync(path.join(actionsDir, newFiles[0]), "utf-8");
 	assert(handoffContent.includes("session/handoff"), "Handoff has session/handoff tag");
-	assert(handoffContent.includes(handoffSessionId), "Handoff includes session ID");
-	assert(handoffContent.includes("deploy to staging"), "Handoff captures user message");
-	assert(handoffContent.includes("rollout undo"), "Handoff captures assistant response");
-	assert(handoffContent.includes("memory-manifest|Memory Manifest"), "Handoff links to manifest");
+	assert(handoffContent.includes("deploy to staging"), "Handoff captures conversation content");
 
-	console.log(`\n  📄 Handoff file: ${handoffFile}`);
-	console.log(`  📏 Handoff size: ${handoffContent.length} chars`);
-
-	// -----------------------------------------------------------------------
-	// TEST 7: Search finds the newly created handoff
-	// -----------------------------------------------------------------------
-	console.log("\n── 7. Search Finds New Handoff ──");
-
-	const searchHandoff = await tools2["memctx_search"].execute(
-		"e2e-6", { query: "rollback staging handoff" }, null, () => {}, {},
-	);
-	assert(
-		searchHandoff.content[0].text.includes("session-handoff"),
-		"Search finds newly created handoff file",
-	);
-
-	// -----------------------------------------------------------------------
-	// Cleanup: remove the handoff file (keep pack clean)
-	// -----------------------------------------------------------------------
-	fs.unlinkSync(path.join(actionsDir, handoffFile));
-
-	// -----------------------------------------------------------------------
-	// Summary
-	// -----------------------------------------------------------------------
 	console.log("\n══════════════════════════════════════");
-	if (process.exitCode) {
-		console.log("❌ Some tests FAILED. See above.");
-	} else {
-		console.log("✅ All E2E tests PASSED.");
-	}
+	if (process.exitCode) console.log("❌ Some tests FAILED. See above.");
+	else console.log("✅ All E2E tests PASSED.");
 	console.log("══════════════════════════════════════\n");
 
 	_resetState();
+	fs.rmSync(TMP_ROOT, { recursive: true, force: true });
 }
 
 main().catch((err) => {
 	console.error("Fatal:", err);
+	try {
+		fs.rmSync(TMP_ROOT, { recursive: true, force: true });
+	} catch {
+		// ignore cleanup errors
+	}
 	process.exit(1);
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -395,7 +395,8 @@ describe("detectActivePack", () => {
 		fs.mkdirSync(path.join(packsDir, "alpha"), { recursive: true });
 		// Returns first in readdir order (implementation-dependent)
 		const result = detectActivePack(packsDir);
-		expect(["zebra", "alpha"]).toContain(result);
+		expect(result).not.toBeNull();
+		expect(["zebra", "alpha"]).toContain(result!);
 	});
 
 	test("ignores .gitkeep file", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["ES2022"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "types": ["node"],
+    "types": ["node", "bun"],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true


### PR DESCRIPTION
## Summary

- Adds community health files, issue/PR templates, security/support policies, and contributor guidance.
- Adds docs for getting started, architecture, safety, search, persistence, development, publishing, and decision records.
- Adds GitHub Actions CI, Dependabot, example memory pack, and reusable note templates.
- Makes e2e tests deterministic by generating a temporary pack and restores TypeScript typecheck.

## Validation

- npm run ci
- npm audit --omit=dev --audit-level=moderate