### PR TITLE
feat: add always-on retrieval and deep pack generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
-        run: npm ci --omit=optional
+        run: npm ci --omit=optional --omit=peer
 
       - name: Run CI
         run: npm run ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
-        run: npm ci --omit=optional --omit=peer
+        run: npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false
 
       - name: Run CI
         run: npm run ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example v0.3.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must look like v1.2.3. Got: $TAG" >&2
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version $VERSION does not match package.json version $PKG_VERSION" >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci --omit=optional
+
+      - name: Run CI
+        run: npm run ci
+
+      - name: Extract changelog
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          awk "
+            /^## \\[$VERSION\\]/ { found=1; print; next }
+            /^## \\[/ && found { exit }
+            found { print }
+          " CHANGELOG.md > RELEASE_NOTES.md
+
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "No changelog section found for $VERSION" >&2
+            exit 1
+          fi
+
+      - name: Pack
+        id: pack
+        shell: bash
+        run: |
+          npm pack --json > pack.json
+          FILE="$(node -e "console.log(require('./pack.json')[0].filename)")"
+          shasum -a 256 "$FILE" > "$FILE.sha256"
+          echo "file=$FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if npm view "pi-memctx@$VERSION" version >/dev/null 2>&1; then
+            echo "pi-memctx@$VERSION is already published on npm. Skipping publish."
+            exit 0
+          fi
+
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is not configured. Skipping npm publish; rerun this workflow after adding the secret."
+            exit 0
+          fi
+
+          npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --notes-file RELEASE_NOTES.md
+            gh release upload "$TAG" \
+              "${{ steps.pack.outputs.file }}" \
+              "${{ steps.pack.outputs.file }}.sha256" \
+              --clobber
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file RELEASE_NOTES.md \
+              "${{ steps.pack.outputs.file }}" \
+              "${{ steps.pack.outputs.file }}.sha256"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI Test
 
 on:
   pull_request:
@@ -9,14 +9,23 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  ci-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
-      - run: npm run ci
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: npm ci --omit=optional
+
+      - name: Run CI
+        run: npm run ci
+
+      - name: Validate package contents
+        run: npm pack --dry-run --json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: npm ci --omit=optional
+        run: npm ci --omit=optional --omit=peer
 
       - name: Run CI
         run: npm run ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: npm ci --omit=optional --omit=peer
+        run: npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false
 
       - name: Run CI
         run: npm run ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-30
+
+### Added
+
+- Added `/pack-status` command with active pack, pack path, qmd status/source/bin/error, qmd collection, strict mode, file count, and last retrieval diagnostics.
+- Added `/memctx-strict on|off|status` and `MEMCTX_STRICT` support for stronger Memory Gate guidance.
+- Added automatic qmd resolution from `MEMCTX_QMD_BIN`, `PATH`, or optional bundled `@tobilu/qmd`.
+- Added `MEMCTX_QMD_PROBE_TIMEOUT_MS` to tune qmd probe timeouts.
+- Added prompt-specific retrieval before each agent turn with grep fallback when qmd is unavailable, times out, or misses.
+- Added Memory Gate guidance to injected context.
+- Added deep deterministic `/pack-generate` discovery for repositories, hidden allowlist repos like `.github`, docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe commands, infrastructure hints, placeholder repos, project notes, observations, runbooks, and indexes.
+- Added `docs/pack-generate.md`.
+- Added release automation plan support through GitHub Actions.
+
+### Changed
+
+- Moved `@sinclair/typebox` to runtime dependencies.
+- Made `@tobilu/qmd` an optional dependency so pi-memctx can degrade safely to grep fallback.
+- Pack generation now creates the full memory-pack directory structure.
+- `memctx_search` now shares the same qmd/grep fallback pipeline as automatic retrieval.
+- Documentation now describes tools, slash commands, qmd resolution, strict mode, pack status, and pack generation.
+
+### Fixed
+
+- qmd probing now fails fast and reports probe errors in `/pack-status`.
+- Generated pack content redacts high-confidence secret-looking values before persistence.
+- CI installs omit optional qmd dependencies for stable core tests.
+
+## [0.2.1] - 2026-04-30
+
 ### Added
 
 - Open-source community health files: contributing guide, security policy, support policy, code of conduct, issue templates, and pull request template.
@@ -18,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - E2E test now generates a temporary deterministic memory pack instead of depending on local files.
 - TypeScript typecheck is part of the supported development workflow.
 
-## [0.1.0]
+## [0.1.0] - 2026-04-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - qmd probing now fails fast and reports probe errors in `/pack-status`.
 - Generated pack content redacts high-confidence secret-looking values before persistence.
-- CI installs omit optional qmd dependencies for stable core tests.
+- CI installs omit optional qmd dependencies and optional peer dependencies for stable core tests.
 
 ## [0.2.1] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pi -e pi-memctx
 /pack-generate
 ```
 
-This scans your repos for `README.md`, `CLAUDE.md`, `go.mod`, `package.json` and builds a memory pack automatically.
+This performs deterministic discovery across your repos — including read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints — then builds a structured memory pack automatically.
 
 ### 2. Let the agent learn organically
 
@@ -138,7 +138,7 @@ pi starts → detect pack for cwd → load context
                                       │
 user sends prompt ────────────────────┤
                                       │
-  1. Search pack for relevant memories (qmd semantic or grep)
+  1. Search pack for relevant memories (qmd when available, grep fallback otherwise)
   2. Build prioritized context (manifest → context → search → actions → decisions → runbooks)
   3. Inject into system prompt (16K char budget)
                                       │
@@ -198,9 +198,14 @@ use memctx_search to find information about deploy
 
 Modes: `keyword` (fast), `semantic` (~2s), `deep` (~10s).
 
-Install [qmd](https://github.com/tobi/qmd) for semantic search: `npm install -g @tobilu/qmd`
+pi-memctx tries to use [qmd](https://github.com/tobi/qmd) automatically. Resolution order:
 
-Without qmd, search uses keyword grep (still works, just less smart).
+1. `MEMCTX_QMD_BIN`
+2. `qmd` on `PATH`
+3. the optional bundled `@tobilu/qmd` dependency at `node_modules/.bin/qmd`
+4. grep fallback
+
+Without qmd, both automatic context injection and `memctx_search` use keyword grep fallback.
 
 ### memctx_save
 
@@ -219,6 +224,8 @@ Types: `observation`, `decision`, `action`, `runbook`, `context`.
 | Command | What |
 |---|---|
 | `/pack` | Switch packs (picker or `/pack name`) |
+| `/pack-status` | Show active pack, qmd status, last retrieval, and strict-mode status |
+| `/memctx-strict` | Toggle stronger retrieval guidance (`/memctx-strict on|off|status`) |
 | `/pack-generate` | Generate pack from repo directory |
 
 ## Multiple packs
@@ -262,6 +269,7 @@ bash benchmark/run.sh
 - [Safety](docs/safety.md)
 - [Search](docs/search.md)
 - [Persistence](docs/persistence.md)
+- [Pack generation](docs/pack-generate.md)
 - [Development](docs/development.md)
 - [Publishing](docs/publishing.md)
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Less tokens = lower API cost. Better answers = less rework. Faster responses = l
 ## Install
 
 ```bash
+pi install npm:pi-memctx
+```
+
+Or install directly from GitHub:
+
+```bash
 pi install git:github.com/weauratech/pi-memctx
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,45 +188,97 @@ Packs are just Markdown files with frontmatter. Edit them in any editor or Obsid
 
 ## Tools
 
-### memctx_search
+pi-memctx exposes tools to the agent. You can ask the agent to use them directly, and the extension also performs automatic retrieval before each turn.
 
-Search across pack files:
+### `memctx_search`
 
-```
+Search across active-pack files:
+
+```txt
 use memctx_search to find information about deploy
 ```
 
-Modes: `keyword` (fast), `semantic` (~2s), `deep` (~10s).
+Parameters:
 
-pi-memctx tries to use [qmd](https://github.com/tobi/qmd) automatically. Resolution order:
+| Parameter | Values | Default | Purpose |
+|---|---|---:|---|
+| `query` | string | required | Search terms or natural-language query. |
+| `mode` | `keyword`, `semantic`, `deep` | `keyword` | Search strategy. Semantic/deep require qmd. |
+| `limit` | number | `5` | Maximum result count. |
+
+Search behavior:
+
+1. qmd keyword/semantic/deep search when qmd is available;
+2. grep-style Markdown fallback when qmd is unavailable, times out, or misses;
+3. cross-pack hints when the active pack has no match but another pack appears relevant.
+
+qmd resolution order:
 
 1. `MEMCTX_QMD_BIN`
 2. `qmd` on `PATH`
-3. the optional bundled `@tobilu/qmd` dependency at `node_modules/.bin/qmd`
+3. optional bundled `@tobilu/qmd` dependency at `node_modules/.bin/qmd`
 4. grep fallback
+
+Tuning:
+
+```bash
+MEMCTX_QMD_PROBE_TIMEOUT_MS=3000  # default: 1200
+```
 
 Without qmd, both automatic context injection and `memctx_search` use keyword grep fallback.
 
-### memctx_save
+### `memctx_save`
 
 Persist learnings to the active pack:
 
-```
+```txt
 save this as a decision: we use integer cents for all monetary values
 ```
 
-Types: `observation`, `decision`, `action`, `runbook`, `context`.
+Parameters:
 
-**Safety:** automatically blocks secrets, tokens, API keys, private keys.
+| Parameter | Values | Purpose |
+|---|---|---|
+| `type` | `observation`, `decision`, `action`, `runbook`, `context` | Destination note type. |
+| `title` | string | Note title and filename slug source. |
+| `content` | string | Markdown body. |
+| `tags` | string[] | Optional extra tags. |
+
+Behavior:
+
+- writes Markdown notes with frontmatter into the active pack;
+- appends to existing notes with the same slug;
+- updates a matching index when available;
+- blocks common secret, token, API key, AWS key, and private-key patterns.
 
 ## Commands
 
-| Command | What |
-|---|---|
-| `/pack` | Switch packs (picker or `/pack name`) |
-| `/pack-status` | Show active pack, qmd status, last retrieval, and strict-mode status |
-| `/memctx-strict` | Toggle stronger retrieval guidance (`/memctx-strict on|off|status`) |
-| `/pack-generate` | Generate pack from repo directory |
+These slash commands are available inside Pi after the extension loads.
+
+| Command | Usage | What |
+|---|---|---|
+| `/pack` | `/pack` or `/pack <name>` | List packs with a picker or switch directly. |
+| `/pack-status` | `/pack-status` | Show active pack, pack path, qmd status/source/bin/error, qmd collection, strict mode, file count, and last retrieval. |
+| `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. In strict mode, project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
+| `/pack-generate` | `/pack-generate [path] [slug]` | Generate a structured pack from a directory of repositories. |
+
+### `/pack-status` example
+
+```txt
+Active pack: opensource
+Pack path: ~/.pi/agent/memory-vault/packs/opensource
+qmd: unavailable
+qmd source: local-dependency
+qmd error: probe timed out
+Strict mode: off
+Last retrieval: grep-fallback
+```
+
+### `/pack-generate` discovery
+
+`/pack-generate` now performs deterministic local discovery before writing notes. It detects normal repos, hidden allowlist repos like `.github`, Git remotes, Node/TS and Go manifests, package scripts, safe commands, GitHub Actions, read-first docs, infra hints, placeholder repos, and redacts sensitive-looking values before persistence.
+
+See [Pack generation](docs/pack-generate.md) for details.
 
 ## Multiple packs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,16 +8,18 @@ pi-memctx is a single Pi extension implemented in `index.ts`.
 session_start
   -> resolve pack directory
   -> detect active pack
+  -> resolve qmd from MEMCTX_QMD_BIN, PATH, or bundled optional dependency
   -> optionally index with qmd
 
 before_agent_start
-  -> search active pack for prompt-relevant context
+  -> search active pack for prompt-relevant context with qmd when available
+  -> fall back to grep-style Markdown search when qmd is unavailable or returns no result
   -> build bounded context block
-  -> append context to the system prompt
+  -> append context plus Memory Gate guidance to the system prompt
 
 memctx_search
   -> qmd keyword/semantic/deep search when available
-  -> grep-style Markdown fallback when qmd is unavailable
+  -> grep-style Markdown fallback when qmd is unavailable or misses
 
 memctx_save
   -> validate content against secret patterns
@@ -26,6 +28,11 @@ memctx_save
 
 session_before_compact
   -> write a compact handoff action note
+
+pack-generate
+  -> discover repositories under the target directory
+  -> collect sanitized evidence from docs, manifests, workflows, git, and safe command sources
+  -> write full pack structure, resource map, context notes, project notes, observations, runbooks, and indexes
 ```
 
 ## Design principles
@@ -33,5 +40,8 @@ session_before_compact
 - Local-first: no hosted service is required.
 - Markdown-first: memory is reviewable with normal tools.
 - Bounded context: lower-priority sections are trimmed before flooding the prompt.
-- qmd optional: semantic search is an enhancement, not a hard dependency.
+- qmd optional: semantic search is attempted automatically when available, but grep fallback remains the hard guarantee.
+- Observable memory state: `/pack-status` reports active pack, qmd resolution, and last retrieval.
+- Strict guidance is opt-in via `MEMCTX_STRICT=true` or `/memctx-strict on`.
 - Source of truth wins: repository files and live system state override memory notes.
+- Generated memory is conservative: deterministic pack generation avoids destructive commands and redacts sensitive-looking values.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,6 +26,8 @@ Use `/pack-generate` inside a Pi session:
 /pack-generate /path/to/repos my-project
 ```
 
+The generator performs deterministic local discovery of repositories, read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints. See [Pack generation](pack-generate.md).
+
 Or create folders manually:
 
 ```txt
@@ -46,6 +48,13 @@ See `examples/basic-pack/` for a minimal public-safe pack.
 ```txt
 /pack
 /pack my-project
+/pack-status
+```
+
+Use strict mode when you want stronger retrieval guidance before project-specific answers:
+
+```txt
+/memctx-strict on
 ```
 
 Ask the agent to search memory:
@@ -53,6 +62,8 @@ Ask the agent to search memory:
 ```txt
 Use memctx_search to find the deploy runbook.
 ```
+
+pi-memctx also retrieves prompt-relevant memory automatically before each turn. It uses qmd when available and grep fallback otherwise.
 
 Ask the agent to save durable memory:
 

--- a/docs/pack-generate.md
+++ b/docs/pack-generate.md
@@ -1,0 +1,54 @@
+# Pack generation
+
+`/pack-generate` creates a memory pack from a directory of repositories.
+
+```txt
+/pack-generate /path/to/repos my-project
+```
+
+If no path is provided, pi-memctx scans the current working directory. If no slug is provided, it derives one from the scanned directory name.
+
+## Deterministic discovery
+
+The generator performs local-only discovery and writes a structured pack before any future LLM enrichment step. It detects:
+
+- normal top-level repositories;
+- hidden repository allowlist entries such as `.github` and `.gitlab`;
+- Git remotes and current branch when available;
+- Node/TypeScript projects from `package.json` and lockfiles;
+- Go projects from `go.mod`;
+- infrastructure/config hints such as Docker, Terraform, Helm, Kubernetes, `infra/`, and CI workflows;
+- read-first docs such as `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, and selected `docs/**/*.md` files;
+- safe development commands from package scripts, Go manifests, and Make targets.
+
+## Generated structure
+
+The generated pack uses the full memory-pack layout:
+
+```txt
+00-system/pi-agent/memory-manifest.md
+00-system/pi-agent/retrieval-protocol.md
+00-system/pi-agent/resource-map.md
+00-system/indexes/*.md
+10-user/
+20-context/overview.md
+20-context/<repo>.md
+30-projects/<repo>.md
+40-actions/
+50-decisions/
+60-observations/workspace-repository-map.md
+70-runbooks/<repo>-development.md
+80-sessions/
+```
+
+Runbooks are generated only when safe setup/check commands are inferred. Deploy, production, release, publish, destructive, and credential-related commands are excluded from generated runbooks.
+
+## Safety and redaction
+
+The generator skips sensitive file names such as `.env`, private keys, credential files, and secret files. It also redacts high-confidence secret-looking values before writing notes.
+
+Generated notes are context, not authority. Source-of-truth repository files, tests, CI, and live runtime facts override memory.
+
+## Current limitation
+
+This phase is deterministic. LLM-assisted synthesis and `/pack-enrich` are planned as follow-up phases so generated notes can be further summarized without overwriting human-authored memory.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -12,7 +12,7 @@ pi install git:github.com/weauratech/pi-memctx
 Releases are tag-driven. Pushing a tag like `v0.3.0` runs `.github/workflows/release.yml`, which:
 
 1. validates that the tag version matches `package.json`;
-2. installs dependencies with `npm ci --omit=optional --omit=peer`;
+2. installs dependencies with `npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false`;
 3. runs `npm run ci`;
 4. extracts release notes from `CHANGELOG.md`;
 5. runs `npm pack --json`;

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,18 +1,55 @@
 # Publishing
 
-This project is installable directly from GitHub with Pi:
+pi-memctx is published to npm and can also be installed directly from GitHub with Pi:
 
 ```bash
+pi install npm:pi-memctx
 pi install git:github.com/weauratech/pi-memctx
 ```
 
-Before publishing a release:
+## Release workflow
+
+Releases are tag-driven. Pushing a tag like `v0.3.0` runs `.github/workflows/release.yml`, which:
+
+1. validates that the tag version matches `package.json`;
+2. installs dependencies with `npm ci --omit=optional`;
+3. runs `npm run ci`;
+4. extracts release notes from `CHANGELOG.md`;
+5. runs `npm pack --json`;
+6. generates a SHA-256 checksum for the tarball;
+7. publishes the tarball to npm when `NPM_TOKEN` is configured;
+8. creates or updates the GitHub Release and uploads the tarball plus checksum.
+
+The publish step is idempotent: if the version already exists on npm, it skips publishing. If `NPM_TOKEN` is not configured, the workflow still creates/updates the GitHub Release and can be rerun after the secret is added.
+
+## Required secret
+
+Configure this GitHub Actions secret before publishing to npm:
+
+```txt
+NPM_TOKEN
+```
+
+The workflow also requests `id-token: write` so the project can migrate to npm Trusted Publishing later.
+
+## Before publishing a release
 
 1. Run `npm run ci`.
-2. Review `SECURITY.md` and ensure no sensitive data was committed.
-3. Update `CHANGELOG.md`.
-4. Create a version tag, for example `v0.1.1`.
-5. Publish GitHub release notes from the changelog.
+2. Run `npm pack --dry-run --json` and inspect included files.
+3. Review `SECURITY.md` and ensure no sensitive data was committed.
+4. Update `CHANGELOG.md` with a section matching the release version, for example `## [0.3.0] - YYYY-MM-DD`.
+5. Update `package.json` and `package-lock.json` to the same version.
+6. Merge the release commit to `main`.
+7. Create and push the tag:
+
+```bash
+git checkout main
+git pull
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+## Versioning
 
 Use semantic versioning where practical:
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -12,7 +12,7 @@ pi install git:github.com/weauratech/pi-memctx
 Releases are tag-driven. Pushing a tag like `v0.3.0` runs `.github/workflows/release.yml`, which:
 
 1. validates that the tag version matches `package.json`;
-2. installs dependencies with `npm ci --omit=optional`;
+2. installs dependencies with `npm ci --omit=optional --omit=peer`;
 3. runs `npm run ci`;
 4. extracts release notes from `CHANGELOG.md`;
 5. runs `npm pack --json`;

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,6 +1,6 @@
 # Search
 
-`memctx_search` searches the active memory pack.
+`memctx_search` searches the active memory pack. Automatic context injection also performs prompt-specific retrieval before each agent turn.
 
 ## Modes
 
@@ -8,7 +8,7 @@
 - `semantic`: meaning-based search when qmd is installed.
 - `deep`: hybrid/reranked search when qmd is installed.
 
-Without qmd, pi-memctx falls back to local grep-style Markdown search.
+qmd is resolved from `MEMCTX_QMD_BIN`, `PATH`, or the optional bundled `@tobilu/qmd` dependency. Without qmd, pi-memctx falls back to local grep-style Markdown search.
 
 ## Examples
 
@@ -20,8 +20,11 @@ memctx_search(query="incident runbook for queue lag", mode="deep", limit=3)
 
 ## qmd
 
-Install qmd if you want semantic/deep search:
+pi-memctx attempts to use qmd automatically:
 
-```bash
-npm install -g @tobilu/qmd
-```
+1. `MEMCTX_QMD_BIN`
+2. `qmd` on `PATH`
+3. `node_modules/.bin/qmd` from the optional bundled dependency
+4. grep fallback
+
+Use `/pack-status` to see which path is active.

--- a/index.ts
+++ b/index.ts
@@ -81,6 +81,7 @@ export type QmdStatus = {
 	bin?: string;
 	version?: string;
 	source: QmdSource;
+	error?: string;
 };
 
 type RetrievalStatus = {
@@ -202,6 +203,30 @@ function firstExistingExecutable(candidates: string[]): string | null {
 	return null;
 }
 
+function qmdProbeTimeoutMs(): number {
+	const parsed = Number.parseInt(process.env.MEMCTX_QMD_PROBE_TIMEOUT_MS ?? "1200", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 1200;
+}
+
+function readLocalQmdPackageVersion(binPath: string): string | undefined {
+	let dir = path.dirname(binPath);
+	for (let i = 0; i < 6; i++) {
+		const pkgPath = path.join(dir, "package.json");
+		if (fs.existsSync(pkgPath)) {
+			try {
+				const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+				if (pkg.name === "@tobilu/qmd" && pkg.version) return `qmd ${pkg.version}`;
+			} catch {
+				return undefined;
+			}
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return undefined;
+}
+
 export function resolveQmdBinary(): { bin: string; source: Exclude<QmdSource, "missing"> } | null {
 	if (process.env.MEMCTX_QMD_BIN) {
 		return { bin: process.env.MEMCTX_QMD_BIN, source: "env" };
@@ -230,16 +255,24 @@ export async function detectQmdStatus(): Promise<QmdStatus> {
 	if (!resolved) return { available: false, source: "missing" };
 
 	return new Promise((resolve) => {
-		execFile(resolved.bin, ["--version"], { timeout: 5000 }, (err, stdout, stderr) => {
+		const fallbackVersion = readLocalQmdPackageVersion(resolved.bin);
+		execFile(resolved.bin, ["--version"], { timeout: qmdProbeTimeoutMs() }, (err, stdout, stderr) => {
 			if (err) {
-				resolve({ available: false, bin: resolved.bin, source: resolved.source });
+				const message = err instanceof Error ? err.message : String(err);
+				resolve({
+					available: false,
+					bin: resolved.bin,
+					source: resolved.source,
+					version: fallbackVersion,
+					error: message.includes("timed out") ? "probe timed out" : message,
+				});
 				return;
 			}
 			resolve({
 				available: true,
 				bin: resolved.bin,
 				source: resolved.source,
-				version: (stdout || stderr).trim().split(/\s+/).slice(0, 3).join(" "),
+				version: (stdout || stderr).trim().split(/\s+/).slice(0, 3).join(" ") || fallbackVersion,
 			});
 		});
 	});
@@ -1638,6 +1671,7 @@ export default function (pi: ExtensionAPI) {
 				`qmd source: ${qmdStatus.source}`,
 				`qmd bin: ${qmdStatus.bin ?? "<none>"}`,
 				`qmd version: ${qmdStatus.version ?? "<unknown>"}`,
+				`qmd error: ${qmdStatus.error ?? "<none>"}`,
 				`qmd collection: ${qmdCollection || "<none>"}`,
 				`Strict mode: ${strictMode ? "on" : "off"}`,
 				...retrieval,

--- a/index.ts
+++ b/index.ts
@@ -1778,7 +1778,8 @@ export default function (pi: ExtensionAPI) {
 			let packsDir = _packsDir;
 			if (!packsDir) {
 				// Try to find existing packs dir
-				packsDir = resolvePacksDir(ctx.cwd);
+				const resolvedPacksDir = resolvePacksDir(ctx.cwd);
+				if (resolvedPacksDir) packsDir = resolvedPacksDir;
 			}
 			if (!packsDir) {
 				// Create default global packs directory

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@
  *   - Obsidian-compatible pack structure preserved
  */
 
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
@@ -69,7 +69,34 @@ let vaultRoot = "";
 let activePack = "";
 let activePackPath = "";
 let qmdAvailable = false;
+let qmdBin = "";
 let qmdCollection = "";
+let strictMode = parseBooleanEnv(process.env.MEMCTX_STRICT);
+
+type SearchMode = "keyword" | "semantic" | "deep";
+type QmdSource = "env" | "path" | "local-dependency" | "missing";
+
+export type QmdStatus = {
+	available: boolean;
+	bin?: string;
+	version?: string;
+	source: QmdSource;
+};
+
+type RetrievalStatus = {
+	prompt: string;
+	mode: "qmd" | "grep-fallback" | "none";
+	query: string;
+	resultCount: number;
+	timestamp: string;
+};
+
+let qmdStatus: QmdStatus = { available: false, source: "missing" };
+let lastRetrieval: RetrievalStatus | null = null;
+
+function parseBooleanEnv(value: string | undefined): boolean {
+	return ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
+}
 
 // ---------------------------------------------------------------------------
 // Public helpers (exported for testing)
@@ -164,27 +191,80 @@ export function detectActivePack(packsDir: string, cwd?: string): string | null 
 	return packs[0];
 }
 
-export async function detectQmd(): Promise<boolean> {
+function executableName(name: string): string {
+	return process.platform === "win32" ? `${name}.cmd` : name;
+}
+
+function firstExistingExecutable(candidates: string[]): string | null {
+	for (const candidate of candidates) {
+		if (candidate && fs.existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+export function resolveQmdBinary(): { bin: string; source: Exclude<QmdSource, "missing"> } | null {
+	if (process.env.MEMCTX_QMD_BIN) {
+		return { bin: process.env.MEMCTX_QMD_BIN, source: "env" };
+	}
+
+	const pathEntries = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+	const pathMatch = firstExistingExecutable(pathEntries.map((entry) => path.join(entry, executableName("qmd"))));
+	if (pathMatch) return { bin: pathMatch, source: "path" };
+
+	const localCandidates: string[] = [];
+	let dir = __dirname;
+	for (let i = 0; i < 8; i++) {
+		localCandidates.push(path.join(dir, "node_modules", ".bin", executableName("qmd")));
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	const localMatch = firstExistingExecutable(localCandidates);
+	if (localMatch) return { bin: localMatch, source: "local-dependency" };
+
+	return null;
+}
+
+export async function detectQmdStatus(): Promise<QmdStatus> {
+	const resolved = resolveQmdBinary();
+	if (!resolved) return { available: false, source: "missing" };
+
 	return new Promise((resolve) => {
-		execFile("qmd", ["--version"], { timeout: 5000 }, (err) => {
-			resolve(!err);
+		execFile(resolved.bin, ["--version"], { timeout: 5000 }, (err, stdout, stderr) => {
+			if (err) {
+				resolve({ available: false, bin: resolved.bin, source: resolved.source });
+				return;
+			}
+			resolve({
+				available: true,
+				bin: resolved.bin,
+				source: resolved.source,
+				version: (stdout || stderr).trim().split(/\s+/).slice(0, 3).join(" "),
+			});
 		});
 	});
+}
+
+export async function detectQmd(): Promise<boolean> {
+	qmdStatus = await detectQmdStatus();
+	qmdAvailable = qmdStatus.available;
+	qmdBin = qmdStatus.bin ?? "";
+	return qmdAvailable;
 }
 
 export async function qmdSearch(
 	query: string,
 	collection: string,
 	limit = 5,
-	mode: "keyword" | "semantic" | "deep" = "keyword",
+	mode: SearchMode = "keyword",
 ): Promise<string> {
-	if (!qmdAvailable) return "";
+	if (!qmdAvailable || !qmdBin) return "";
 	return new Promise((resolve) => {
 		const args = ["search", query, "-n", String(limit), "-c", collection];
 		if (mode === "semantic") args.push("--semantic");
 		else if (mode === "deep") args.push("--deep");
 
-		execFile("qmd", args, { timeout: mode === "deep" ? 15000 : 5000 }, (err, stdout) => {
+		execFile(qmdBin, args, { timeout: mode === "deep" ? 15000 : 5000 }, (err, stdout) => {
 			if (err) {
 				resolve("");
 				return;
@@ -195,12 +275,60 @@ export async function qmdSearch(
 }
 
 export async function qmdEmbed(collection: string, packPath: string): Promise<boolean> {
-	if (!qmdAvailable) return false;
+	if (!qmdAvailable || !qmdBin) return false;
 	return new Promise((resolve) => {
-		execFile("qmd", ["embed", "-c", collection, packPath], { timeout: 30000 }, (err) => {
+		execFile(qmdBin, ["embed", "-c", collection, packPath], { timeout: 30000 }, (err) => {
 			resolve(!err);
 		});
 	});
+}
+
+export function grepSearchPack(packPath: string, query: string, limit = 5): { text: string; matchCount: number } {
+	const files = scanPackFiles(packPath);
+	const matches: string[] = [];
+	const queryLower = query.toLowerCase();
+	const terms = queryLower.split(/\s+/).filter(Boolean);
+
+	if (terms.length === 0) return { text: "", matchCount: 0 };
+
+	for (const f of files) {
+		if (matches.length >= limit) break;
+		const content = readFileSafe(f);
+		if (!content) continue;
+		const contentLower = content.toLowerCase();
+		const score = terms.filter((t) => contentLower.includes(t)).length;
+		if (score > 0) {
+			const rel = path.relative(packPath, f);
+			const lines = content.split("\n");
+			const matchingLines = lines
+				.filter((line) => terms.some((t) => line.toLowerCase().includes(t)))
+				.slice(0, 5);
+			matches.push(`### ${rel} (${score}/${terms.length} terms matched)\n${matchingLines.join("\n")}`);
+		}
+	}
+
+	return { text: matches.join("\n\n"), matchCount: matches.length };
+}
+
+export async function searchPackMemory(
+	packPath: string,
+	query: string,
+	limit = 5,
+	mode: SearchMode = "keyword",
+): Promise<{ text: string; mode: "qmd" | "grep-fallback" | "none"; matchCount: number }> {
+	if (qmdAvailable) {
+		const qmdResults = await qmdSearch(query, qmdCollection, limit, mode);
+		if (qmdResults.trim()) {
+			return { text: qmdResults, mode: "qmd", matchCount: qmdResults.split("\n").filter((line) => line.trim()).length };
+		}
+	}
+
+	const grepResults = grepSearchPack(packPath, query, limit);
+	if (grepResults.matchCount > 0) {
+		return { text: grepResults.text, mode: "grep-fallback", matchCount: grepResults.matchCount };
+	}
+
+	return { text: "", mode: "none", matchCount: 0 };
 }
 
 /**
@@ -597,10 +725,465 @@ export function resolvePacksDir(cwd: string): string | null {
 	return null;
 }
 
+
+type EvidenceFile = {
+	path: string;
+	content: string;
+};
+
+type RepoEvidence = {
+	name: string;
+	slug: string;
+	path: string;
+	type: string;
+	status: "active" | "placeholder";
+	description: string;
+	remote: string;
+	currentBranch: string;
+	readFirst: string[];
+	packageManager: string;
+	scripts: Record<string, string>;
+	safeCommands: string[];
+	docs: EvidenceFile[];
+	workflows: EvidenceFile[];
+	infra: string[];
+	tree: string[];
+	observations: string[];
+};
+
+const REPO_HIDDEN_ALLOWLIST = new Set([".github", ".gitlab"]);
+const SKIP_DIRS = new Set([
+	".git",
+	"node_modules",
+	"vendor",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+	".cache",
+	".next",
+	".turbo",
+]);
+const SENSITIVE_FILE_RE = /(^|\/)(\.env(\..*)?|.*\.(pem|key|p12|pfx)|id_rsa|id_ed25519|credentials?|secrets?\..*)$/i;
+const SECRET_VALUE_PATTERNS = [
+	/AKIA[0-9A-Z]{16}/g,
+	/-----BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----[\s\S]*?-----END (RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----/g,
+	/(authorization\s*:\s*bearer\s+)[^\s`'"<>]+/gi,
+	/((?:api[_-]?key|secret|token|password|passwd|pwd)\s*[:=]\s*)[^\s`'"<>]+/gi,
+];
+
+function safeExecGit(repoPath: string, args: string[]): string {
+	try {
+		return execFileSync("git", ["-C", repoPath, ...args], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 2000,
+		}).trim();
+	} catch {
+		return "";
+	}
+}
+
+function sanitizeEvidence(text: string): string {
+	let sanitized = text;
+	for (const pattern of SECRET_VALUE_PATTERNS) {
+		sanitized = sanitized.replace(pattern, (_match, prefix = "") => `${prefix}[REDACTED_SECRET]`);
+	}
+	return sanitized;
+}
+
+function readEvidenceFile(filePath: string, repoPath: string, maxChars = 4000): EvidenceFile | null {
+	const rel = path.relative(repoPath, filePath);
+	if (SENSITIVE_FILE_RE.test(rel)) return null;
+	const content = readFileSafe(filePath);
+	if (!content?.trim()) return null;
+	return { path: rel, content: truncate(sanitizeEvidence(content.trim()), maxChars) };
+}
+
+function listTopLevelEntries(dirPath: string, limit = 60): string[] {
+	try {
+		return fs.readdirSync(dirPath, { withFileTypes: true })
+			.filter((e) => !SKIP_DIRS.has(e.name) && !SENSITIVE_FILE_RE.test(e.name))
+			.map((e) => e.isDirectory() ? `${e.name}/` : e.name)
+			.sort()
+			.slice(0, limit);
+	} catch {
+		return [];
+	}
+}
+
+function findFilesLimited(root: string, predicate: (rel: string, name: string) => boolean, limit = 20, maxDepth = 4): string[] {
+	const found: string[] = [];
+	function walk(dir: string, depth: number) {
+		if (found.length >= limit || depth > maxDepth) return;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (found.length >= limit) break;
+			if (SKIP_DIRS.has(entry.name)) continue;
+			const full = path.join(dir, entry.name);
+			const rel = path.relative(root, full);
+			if (SENSITIVE_FILE_RE.test(rel)) continue;
+			if (entry.isDirectory()) {
+				walk(full, depth + 1);
+			} else if (predicate(rel, entry.name)) {
+				found.push(full);
+			}
+		}
+	}
+	walk(root, 0);
+	return found.sort();
+}
+
+function repoSlugForName(name: string): string {
+	if (name === ".github") return "github-profile";
+	return slugify(name) || "repo";
+}
+
+function detectPackageManager(repoPath: string): string {
+	if (fs.existsSync(path.join(repoPath, "pnpm-lock.yaml"))) return "pnpm";
+	if (fs.existsSync(path.join(repoPath, "bun.lock")) || fs.existsSync(path.join(repoPath, "bun.lockb"))) return "bun";
+	if (fs.existsSync(path.join(repoPath, "yarn.lock"))) return "yarn";
+	if (fs.existsSync(path.join(repoPath, "package-lock.json"))) return "npm";
+	return "npm";
+}
+
+function scriptCommand(pm: string, script: string): string {
+	if (script === "install") {
+		if (pm === "pnpm") return "pnpm install --frozen-lockfile";
+		if (pm === "bun") return "bun install --frozen-lockfile";
+		if (pm === "yarn") return "yarn install --frozen-lockfile";
+		return "npm ci";
+	}
+	if (pm === "pnpm") return `pnpm ${script}`;
+	if (pm === "bun") return `bun run ${script}`;
+	if (pm === "yarn") return `yarn ${script}`;
+	return `npm run ${script}`;
+}
+
+function isSafeScriptName(name: string): boolean {
+	return !/(deploy|destroy|delete|remove|apply|publish|release|prod|production|push|login|secret|token)/i.test(name);
+}
+
+function collectPackageEvidence(repoPath: string): { type: string; description: string; scripts: Record<string, string>; packageManager: string; commands: string[]; observations: string[] } {
+	const packagePath = path.join(repoPath, "package.json");
+	if (!fs.existsSync(packagePath)) return { type: "", description: "", scripts: {}, packageManager: "", commands: [], observations: [] };
+	try {
+		const pkg = JSON.parse(readFileSafe(packagePath) ?? "{}");
+		const packageManager = detectPackageManager(repoPath);
+		const scripts: Record<string, string> = pkg.scripts ?? {};
+		const commands = [scriptCommand(packageManager, "install")];
+		for (const name of Object.keys(scripts)) {
+			if (isSafeScriptName(name) && /^(dev|start|build|test|lint|typecheck|check|ci|format|e2e)$/i.test(name)) {
+				commands.push(scriptCommand(packageManager, name));
+			}
+		}
+		const deps = Object.keys(pkg.dependencies ?? {}).slice(0, 12);
+		const devDeps = Object.keys(pkg.devDependencies ?? {}).slice(0, 12);
+		const observations = [
+			`Package name: ${pkg.name ?? path.basename(repoPath)}`,
+			pkg.version ? `Package version: ${pkg.version}` : "",
+			deps.length ? `Runtime dependencies include: ${deps.join(", ")}` : "",
+			devDeps.length ? `Development dependencies include: ${devDeps.join(", ")}` : "",
+		].filter(Boolean);
+		return {
+			type: "Node/TS",
+			description: pkg.description ?? pkg.name ?? "",
+			scripts,
+			packageManager,
+			commands,
+			observations,
+		};
+	} catch {
+		return { type: "Node/TS", description: "", scripts: {}, packageManager: detectPackageManager(repoPath), commands: [], observations: ["package.json exists but could not be parsed."] };
+	}
+}
+
+function collectGoEvidence(repoPath: string): { type: string; description: string; commands: string[]; observations: string[] } {
+	const gomodPath = path.join(repoPath, "go.mod");
+	if (!fs.existsSync(gomodPath)) return { type: "", description: "", commands: [], observations: [] };
+	const gomod = readFileSafe(gomodPath) ?? "";
+	const moduleLine = gomod.match(/^module\s+(.+)$/m)?.[1] ?? "";
+	const goVersion = gomod.match(/^go\s+(.+)$/m)?.[1] ?? "";
+	return {
+		type: "Go",
+		description: moduleLine,
+		commands: ["go test ./...", "go build ./..."],
+		observations: [moduleLine ? `Go module: ${moduleLine}` : "Go module observed.", goVersion ? `Go version: ${goVersion}` : ""].filter(Boolean),
+	};
+}
+
+function collectMakeCommands(repoPath: string): string[] {
+	const makefile = readFileSafe(path.join(repoPath, "Makefile")) ?? readFileSafe(path.join(repoPath, "makefile"));
+	if (!makefile) return [];
+	const commands: string[] = [];
+	for (const match of makefile.matchAll(/^([a-zA-Z0-9_.-]+):(?:\s|$)/gm)) {
+		const target = match[1];
+		if (isSafeScriptName(target) && /^(test|build|lint|check|format|dev|run)$/i.test(target)) {
+			commands.push(`make ${target}`);
+		}
+	}
+	return commands;
+}
+
+function extractFirstMeaningfulLine(content: string): string {
+	return content.split("\n")
+		.map((line) => line.trim())
+		.find((line) => line && !line.startsWith("#") && !line.startsWith("<") && !line.startsWith("[") && !line.startsWith("!"))
+		?.slice(0, 200) ?? "";
+}
+
+function collectRepoEvidence(repoPath: string, name: string): RepoEvidence {
+	const slug = repoSlugForName(name);
+	const topLevel = listTopLevelEntries(repoPath);
+	const nonGitEntries = topLevel.filter((entry) => entry !== ".git/");
+	const isPlaceholder = nonGitEntries.length === 0;
+	const pkg = collectPackageEvidence(repoPath);
+	const go = collectGoEvidence(repoPath);
+	const hasTerraform = fs.existsSync(path.join(repoPath, "terraform")) || findFilesLimited(repoPath, (rel) => rel.endsWith(".tf"), 3, 3).length > 0;
+	const hasInfra = fs.existsSync(path.join(repoPath, "infra")) || fs.existsSync(path.join(repoPath, "charts")) || fs.existsSync(path.join(repoPath, "helm"));
+	let type = pkg.type || go.type || (hasTerraform || hasInfra ? "IaC" : "unknown");
+	if (name === ".github") type = "GitHub profile/docs";
+
+	const docs: EvidenceFile[] = [];
+	const docNames = ["AGENTS.md", "CLAUDE.md", "README.md", "CONTRIBUTING.md", "SECURITY.md", "CHANGELOG.md", "SUPPORT.md"];
+	for (const docName of docNames) {
+		const doc = readEvidenceFile(path.join(repoPath, docName), repoPath, docName === "README.md" ? 5000 : 3000);
+		if (doc) docs.push(doc);
+	}
+	for (const docPath of findFilesLimited(path.join(repoPath, "docs"), (rel, file) => file.endsWith(".md"), 12, 3)) {
+		const doc = readEvidenceFile(docPath, repoPath, 2500);
+		if (doc && !docs.some((d) => d.path === doc.path)) docs.push(doc);
+	}
+	if (name === ".github") {
+		const profile = readEvidenceFile(path.join(repoPath, "profile", "README.md"), repoPath, 5000);
+		if (profile) docs.push(profile);
+	}
+
+	const workflows = findFilesLimited(path.join(repoPath, ".github", "workflows"), (rel, file) => /\.(ya?ml)$/.test(file), 10, 1)
+		.map((f) => readEvidenceFile(f, repoPath, 2000))
+		.filter((f): f is EvidenceFile => Boolean(f));
+	const infra = [
+		...findFilesLimited(repoPath, (rel) => /(^|\/)(Dockerfile|docker-compose\.ya?ml|compose\.ya?ml)$/.test(rel), 10, 3),
+		...findFilesLimited(repoPath, (rel) => /(^|\/)(terraform|infra|helm|charts|k8s|kubernetes)\//.test(rel) && /\.(tf|ya?ml|yaml|json|md)$/.test(rel), 15, 4),
+	].map((f) => path.relative(repoPath, f));
+
+	const readFirst = docs
+		.map((d) => d.path)
+		.filter((name) => ["AGENTS.md", "CLAUDE.md", "README.md", "profile/README.md", "CONTRIBUTING.md", "SECURITY.md"].includes(name))
+		.slice(0, 8);
+	const readme = docs.find((d) => d.path === "README.md" || d.path === "profile/README.md");
+	const description = pkg.description || go.description || (readme ? extractFirstMeaningfulLine(readme.content) : "") || name;
+	const safeCommands = Array.from(new Set([
+		...pkg.commands,
+		...go.commands,
+		...collectMakeCommands(repoPath),
+	]));
+	const observations = Array.from(new Set([
+		...pkg.observations,
+		...go.observations,
+		workflows.length ? `GitHub Actions workflows observed: ${workflows.map((w) => w.path).join(", ")}` : "",
+		infra.length ? `Infrastructure/config files observed: ${infra.slice(0, 8).join(", ")}` : "",
+		isPlaceholder ? "Repository appears to be empty/placeholder; only Git metadata or no source files observed." : "",
+	].filter(Boolean)));
+
+	return {
+		name,
+		slug,
+		path: repoPath,
+		type,
+		status: isPlaceholder ? "placeholder" : "active",
+		description,
+		remote: safeExecGit(repoPath, ["remote", "get-url", "origin"]) || "unknown/not configured",
+		currentBranch: safeExecGit(repoPath, ["branch", "--show-current"]) || "unknown",
+		readFirst,
+		packageManager: pkg.packageManager,
+		scripts: pkg.scripts,
+		safeCommands,
+		docs,
+		workflows,
+		infra,
+		tree: topLevel,
+		observations,
+	};
+}
+
+function discoverRepositories(scanDir: string): RepoEvidence[] {
+	if (!fs.existsSync(scanDir)) return [];
+	return fs.readdirSync(scanDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.filter((entry) => !entry.name.startsWith(".") || REPO_HIDDEN_ALLOWLIST.has(entry.name))
+		.filter((entry) => !SKIP_DIRS.has(entry.name))
+		.map((entry) => collectRepoEvidence(path.join(scanDir, entry.name), entry.name))
+		.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function yamlList(items: string[]): string {
+	return items.length ? items.map((i) => `  - ${i}`).join("\n") : "  - none";
+}
+
+function writeGeneratedFile(packPath: string, relPath: string, content: string, filesCreated: string[]): void {
+	const filePath = path.join(packPath, relPath);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content.trimEnd() + "\n", "utf-8");
+	filesCreated.push(filePath);
+}
+
+function repoContextNote(packSlug: string, repo: RepoEvidence, today: string): string {
+	const docs = repo.docs.slice(0, 8).map((d) => `### ${d.path}\n\n${d.content}`).join("\n\n");
+	const scripts = Object.keys(repo.scripts).length
+		? Object.entries(repo.scripts).map(([name, cmd]) => `| ${name} | \`${sanitizeEvidence(cmd)}\` |`).join("\n")
+		: "| none observed |  |";
+	const workflows = repo.workflows.length
+		? repo.workflows.map((w) => `### ${w.path}\n\n${w.content}`).join("\n\n")
+		: "No GitHub Actions workflows observed.";
+	return `---
+type: context-pack
+id: context.${packSlug}.${repo.slug}
+title: ${repo.name}
+status: active
+source_of_truth: false
+freshness: current
+last_reviewed: ${today}
+tags:
+  - pack/${packSlug}
+  - agent-memory/context-pack
+  - repo/${repo.slug}
+---
+
+# ${repo.name}
+
+**Type:** ${repo.type}  
+**Status:** ${repo.status}  
+**Description:** ${repo.description}  
+**Local path:** \`${repo.path}\`  
+**Remote:** \`${repo.remote}\`  
+**Current branch:** \`${repo.currentBranch}\`
+
+## Read first
+
+${repo.readFirst.length ? repo.readFirst.map((f) => `- \`${f}\``).join("\n") : "- Inspect repository source before assuming conventions."}
+
+## Safe commands observed
+
+${repo.safeCommands.length ? repo.safeCommands.map((c) => `- \`${c}\``).join("\n") : "No safe development commands inferred."}
+
+## Package scripts
+
+| Script | Command |
+|---|---|
+${scripts}
+
+## Observations
+
+${repo.observations.length ? repo.observations.map((o) => `- ${o}`).join("\n") : "- No high-confidence observations generated."}
+
+## Workflows
+
+${workflows}
+
+## Directory structure
+
+\`\`\`txt
+${repo.tree.join("\n") || "<empty>"}
+\`\`\`
+
+## Source excerpts
+
+${docs || "No documentation excerpts observed."}
+
+## Related
+
+- [[packs/${packSlug}/00-system/pi-agent/resource-map|Resource Map]]
+- [[packs/${packSlug}/00-system/indexes/context-index|Context Index]]
+`;
+}
+
+function repoProjectNote(packSlug: string, repo: RepoEvidence, today: string): string {
+	return `---
+type: project
+id: project.${packSlug}.${repo.slug}
+title: ${repo.name}
+status: ${repo.status === "placeholder" ? "draft" : "active"}
+source_of_truth: false
+freshness: current
+last_reviewed: ${today}
+tags:
+  - pack/${packSlug}
+  - agent-memory/project
+  - repo/${repo.slug}
+---
+
+# ${repo.name}
+
+## Repository
+
+| Field | Value |
+|---|---|
+| Local path | \`${repo.path}\` |
+| Remote | \`${repo.remote}\` |
+| Type | ${repo.type} |
+| Status | ${repo.status} |
+| Current branch | \`${repo.currentBranch}\` |
+
+## Purpose
+
+${repo.description}
+
+## Read-first files
+
+${repo.readFirst.length ? repo.readFirst.map((f) => `- \`${f}\``).join("\n") : "- No read-first files observed."}
+
+## Related
+
+- [[packs/${packSlug}/20-context/${repo.slug}|${repo.name} context]]
+- [[packs/${packSlug}/00-system/indexes/project-index|Project Index]]
+`;
+}
+
+function repoRunbookNote(packSlug: string, repo: RepoEvidence, today: string): string {
+	return `---
+type: runbook
+id: runbook.${packSlug}.${repo.slug}.development
+-title: ${repo.name} Development Runbook
+status: active
+source_of_truth: false
+freshness: current
+last_reviewed: ${today}
+tags:
+  - pack/${packSlug}
+  - agent-memory/runbook
+  - repo/${repo.slug}
+---
+
+# ${repo.name} Development Runbook
+
+Use source-of-truth files in \`${repo.path}\` before changing behavior. The commands below were inferred from manifests and safe script names only.
+
+## Setup and checks
+
+${repo.safeCommands.map((c) => `- \`${c}\``).join("\n")}
+
+## Notes
+
+- Destructive, deploy, release, publish, production, and credential-related commands are intentionally excluded from generated runbooks.
+- If a command fails, inspect the repository README, AGENTS.md, package manifest, Makefile, and CI workflows.
+
+## Related
+
+- [[packs/${packSlug}/20-context/${repo.slug}|${repo.name} context]]
+- [[packs/${packSlug}/00-system/indexes/runbook-index|Runbook Index]]
+`;
+}
+
 /**
  * Scan a directory tree and generate a pack from its contents.
- * Reads README.md, CLAUDE.md, AGENTS.md, go.mod, package.json,
- * Makefile, Dockerfile, and directory structure to build context.
+ * Performs deterministic discovery of repositories, docs, stacks, scripts,
+ * workflows, git remotes, safe development commands, and source-truth pointers.
  */
 export function generatePackFromDirectory(
 	scanDir: string,
@@ -609,64 +1192,31 @@ export function generatePackFromDirectory(
 ): { packPath: string; filesCreated: string[] } {
 	const packPath = path.join(packsDir, packSlug);
 	const filesCreated: string[] = [];
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayStr();
 	const title = packSlug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 
-	// Create directory structure
 	for (const dir of [
 		"00-system/pi-agent",
 		"00-system/indexes",
+		"00-system/local",
+		"10-user",
 		"20-context",
+		"30-projects",
+		"40-actions",
 		"50-decisions",
+		"60-observations",
 		"70-runbooks",
+		"80-sessions",
 	]) {
 		fs.mkdirSync(path.join(packPath, dir), { recursive: true });
 	}
 
-	// Scan for repos (directories with go.mod, package.json, or README.md)
-	const repos: { name: string; type: string; description: string; path: string }[] = [];
-	const topDirs = fs.existsSync(scanDir)
-		? fs.readdirSync(scanDir, { withFileTypes: true }).filter((e) => e.isDirectory() && !e.name.startsWith("."))
-		: [];
+	const repos = discoverRepositories(scanDir);
+	const contextEntries: string[] = [];
+	const projectEntries: string[] = [];
+	const runbookEntries: string[] = [];
 
-	for (const entry of topDirs) {
-		const dirPath = path.join(scanDir, entry.name);
-		let type = "unknown";
-		let description = "";
-
-		if (fs.existsSync(path.join(dirPath, "go.mod"))) {
-			type = "Go";
-			const gomod = readFileSafe(path.join(dirPath, "go.mod"));
-			const moduleLine = gomod?.match(/^module\s+(.+)$/m);
-			if (moduleLine) description = moduleLine[1];
-		} else if (fs.existsSync(path.join(dirPath, "package.json"))) {
-			type = "Node/TS";
-			try {
-				const pkg = JSON.parse(readFileSafe(path.join(dirPath, "package.json")) ?? "{}");
-				description = pkg.description ?? pkg.name ?? "";
-			} catch { /* ignore */ }
-		} else if (fs.existsSync(path.join(dirPath, "infra")) || fs.existsSync(path.join(dirPath, "terraform"))) {
-			type = "IaC";
-		}
-
-		// Read README for description
-		for (const readmeFile of ["README.md", "CLAUDE.md", "AGENTS.md"]) {
-			const readme = readFileSafe(path.join(dirPath, readmeFile));
-			if (readme) {
-				// Extract first meaningful line after heading
-				const lines = readme.split("\n").filter((l) => l.trim() && !l.startsWith("#") && !l.startsWith("<") && !l.startsWith("["));
-				if (lines.length > 0 && !description) {
-					description = lines[0].trim().slice(0, 200);
-				}
-				break;
-			}
-		}
-
-		repos.push({ name: entry.name, type, description: description || entry.name, path: dirPath });
-	}
-
-	// --- Generate manifest ---
-	const manifestContent = `---
+	writeGeneratedFile(packPath, "00-system/pi-agent/memory-manifest.md", `---
 type: system
 id: system.${packSlug}.memory-manifest
 title: ${title} Memory Manifest
@@ -681,30 +1231,61 @@ tags:
 
 # ${title} Memory Manifest
 
-This pack stores context for **${title}**.
+This pack stores safe durable context generated from \`${scanDir}\`.
 
 ## Pack root
 
 \`packs/${packSlug}\`
 
+## Entry order
+
+1. [[packs/${packSlug}/00-system/pi-agent/retrieval-protocol|Retrieval Protocol]]
+2. [[packs/${packSlug}/00-system/pi-agent/resource-map|Resource Map]]
+3. Relevant indexes under \`00-system/indexes/\`
+4. Context and project notes generated from repository source files
+5. Source-of-truth repository files when behavior matters
+
 ## Indexes
 
 - [[packs/${packSlug}/00-system/indexes/context-index|Context Index]]
+- [[packs/${packSlug}/00-system/indexes/project-index|Project Index]]
+- [[packs/${packSlug}/00-system/indexes/action-index|Action Index]]
+- [[packs/${packSlug}/00-system/indexes/decision-index|Decision Index]]
+- [[packs/${packSlug}/00-system/indexes/observation-index|Observation Index]]
+- [[packs/${packSlug}/00-system/indexes/runbook-index|Runbook Index]]
+- [[packs/${packSlug}/00-system/indexes/session-index|Session Index]]
 
 ## Safety
 
-Never store secrets, tokens, passwords, private keys, credentials, or sensitive data.
-`;
-	const manifestPath = path.join(packPath, "00-system/pi-agent/memory-manifest.md");
-	fs.writeFileSync(manifestPath, manifestContent);
-	filesCreated.push(manifestPath);
+Generated content is sanitized with high-confidence secret redaction. Never store secrets, credentials, private keys, tokens, customer data, or sensitive payloads.
+`, filesCreated);
 
-	// --- Generate resource-map ---
-	const repoTable = repos
-		.map((r) => `| \`${r.name}\` | ${r.type} | ${r.description.slice(0, 100)} |`)
-		.join("\n");
+	writeGeneratedFile(packPath, "00-system/pi-agent/retrieval-protocol.md", `---
+type: system
+id: system.${packSlug}.retrieval-protocol
+title: Retrieval Protocol
+status: active
+source_of_truth: true
+freshness: current
+last_reviewed: ${today}
+tags:
+  - agent-memory/retrieval
+  - pack/${packSlug}
+---
 
-	const resourceMapContent = `---
+# Retrieval Protocol
+
+Before working with repositories from \`${scanDir}\`:
+
+1. Read [[packs/${packSlug}/00-system/pi-agent/resource-map|Resource Map]].
+2. Read the repository-specific context note in \`20-context/\`.
+3. Read repository-local source-of-truth instructions such as \`AGENTS.md\`, \`CLAUDE.md\`, \`README.md\`, \`CONTRIBUTING.md\`, and relevant docs.
+4. Use generated runbooks only as safe starting points; source files, tests, CI, and live runtime facts win.
+5. Do not persist or expose secrets, credentials, customer data, or sensitive payloads.
+`, filesCreated);
+
+	const repoRows = repos.map((r) => `| \`${r.name}\` | ${r.type} | ${r.status} | \`${r.path}\` | \`${r.remote}\` | ${r.readFirst.map((f) => `\`${f}\``).join(", ") || "inspect source"} |`).join("\n");
+	writeGeneratedFile(packPath, "00-system/pi-agent/resource-map.md", `---
 type: system
 id: system.${packSlug}.resource-map
 title: Resource Map
@@ -719,52 +1300,27 @@ tags:
 
 # Resource Map
 
-## Repositories
-
-| Name | Type | Description |
-|---|---|---|
-${repoTable}
-
 ## Source directory
 
 \`${scanDir}\`
-`;
-	const resourceMapPath = path.join(packPath, "00-system/pi-agent/resource-map.md");
-	fs.writeFileSync(resourceMapPath, resourceMapContent);
-	filesCreated.push(resourceMapPath);
 
-	// --- Generate context pack per repo ---
-	const contextEntries: string[] = [];
+## Repositories
 
-	for (const repo of repos) {
-		const parts: string[] = [];
+| Name | Type | Status | Local path | Remote | Read first |
+|---|---|---|---|---|---|
+${repoRows || "| none observed | unknown | placeholder | - | - | - |"}
 
-		// Read README
-		const readme = readFileSafe(path.join(repo.path, "README.md"));
-		if (readme) {
-			parts.push(truncate(readme, 3000));
-		}
+## Safety
 
-		// Read CLAUDE.md or AGENTS.md for build/deploy commands
-		for (const agentFile of ["CLAUDE.md", "AGENTS.md"]) {
-			const content = readFileSafe(path.join(repo.path, agentFile));
-			if (content) {
-				parts.push(`## From ${agentFile}\n\n${truncate(content, 2000)}`);
-				break;
-			}
-		}
+- Treat generated notes as context, not authority.
+- Source-of-truth files in repositories override memory notes.
+- Secret-like values are redacted as \`[REDACTED_SECRET]\` before persistence.
+`, filesCreated);
 
-		// Scan top-level structure
-		const topLevel = fs.readdirSync(repo.path, { withFileTypes: true })
-			.filter((e) => !e.name.startsWith(".") && e.name !== "node_modules" && e.name !== "vendor")
-			.map((e) => e.isDirectory() ? `${e.name}/` : e.name)
-			.slice(0, 30);
-		parts.push(`## Directory structure\n\n\`\`\`\n${topLevel.join("\n")}\n\`\`\``);
-
-		const contextContent = `---
+	writeGeneratedFile(packPath, "20-context/overview.md", `---
 type: context-pack
-id: context.${packSlug}.${repo.name}
-title: ${repo.name}
+id: context.${packSlug}.overview
+title: ${title} Overview
 status: active
 source_of_truth: false
 freshness: current
@@ -772,34 +1328,75 @@ last_reviewed: ${today}
 tags:
   - pack/${packSlug}
   - agent-memory/context-pack
-  - repo/${repo.name}
 ---
 
-# ${repo.name}
+# ${title} Overview
 
-**Type:** ${repo.type}  
-**Description:** ${repo.description}
+Generated from \`${scanDir}\`.
 
-${parts.join("\n\n")}
+## Repositories
+
+${repos.map((r) => `- [[packs/${packSlug}/20-context/${r.slug}|${r.name}]] — ${r.type}, ${r.status}, ${r.description}`).join("\n") || "No repositories observed."}
 
 ## Related
 
 - [[packs/${packSlug}/00-system/pi-agent/resource-map|Resource Map]]
-`;
-		const contextPath = path.join(packPath, `20-context/${repo.name}.md`);
-		fs.writeFileSync(contextPath, contextContent);
-		filesCreated.push(contextPath);
+- [[packs/${packSlug}/00-system/indexes/context-index|Context Index]]
+`, filesCreated);
+	contextEntries.push(`| [[packs/${packSlug}/20-context/overview|${title} Overview]] | Workspace overview generated from ${scanDir}. |`);
 
-		contextEntries.push(
-			`| [[packs/${packSlug}/20-context/${repo.name}\\|${repo.name}]] | ${repo.type} — ${repo.description.slice(0, 60)} |`,
-		);
+	for (const repo of repos) {
+		writeGeneratedFile(packPath, `20-context/${repo.slug}.md`, repoContextNote(packSlug, repo, today), filesCreated);
+		writeGeneratedFile(packPath, `30-projects/${repo.slug}.md`, repoProjectNote(packSlug, repo, today), filesCreated);
+		contextEntries.push(`| [[packs/${packSlug}/20-context/${repo.slug}|${repo.name}]] | ${repo.type} — ${repo.description.slice(0, 80)} |`);
+		projectEntries.push(`| [[packs/${packSlug}/30-projects/${repo.slug}|${repo.name}]] | ${repo.status} ${repo.type} repository. |`);
+		if (repo.safeCommands.length > 0) {
+			writeGeneratedFile(packPath, `70-runbooks/${repo.slug}-development.md`, repoRunbookNote(packSlug, repo, today).replace("\n-title:", "\ntitle:"), filesCreated);
+			runbookEntries.push(`| [[packs/${packSlug}/70-runbooks/${repo.slug}-development|${repo.name} Development Runbook]] | Safe generated setup/check commands. |`);
+		}
 	}
 
-	// --- Generate context index ---
-	const contextIndexContent = `---
+	writeGeneratedFile(packPath, "60-observations/workspace-repository-map.md", `---
+type: observation
+id: observation.${packSlug}.workspace-repository-map
+title: Workspace Repository Map
+status: active
+source_of_truth: false
+freshness: current
+last_reviewed: ${today}
+tags:
+  - pack/${packSlug}
+  - agent-memory/observation
+---
+
+# Workspace Repository Map
+
+## Generated discovery
+
+| Repository | Type | Status | Observations |
+|---|---|---|---|
+${repos.map((r) => `| ${r.name} | ${r.type} | ${r.status} | ${r.observations.slice(0, 3).join("<br>") || "No generated observations."} |`).join("\n") || "| none | unknown | placeholder | No repositories observed. |"}
+
+## Related
+
+- [[packs/${packSlug}/00-system/pi-agent/resource-map|Resource Map]]
+- [[packs/${packSlug}/00-system/indexes/observation-index|Observation Index]]
+`, filesCreated);
+
+	const indexSpecs: Array<[string, string, string[]]> = [
+		["context-index.md", "Context Index", contextEntries],
+		["project-index.md", "Project Index", projectEntries],
+		["action-index.md", "Action Index", ["| <Add wikilink> | <Purpose> |"]],
+		["decision-index.md", "Decision Index", ["| <Add wikilink> | <Purpose> |"]],
+		["observation-index.md", "Observation Index", [`| [[packs/${packSlug}/60-observations/workspace-repository-map|Workspace Repository Map]] | Generated repository discovery observations. |`]],
+		["runbook-index.md", "Runbook Index", runbookEntries.length ? runbookEntries : ["| <Add wikilink> | <Purpose> |"]],
+		["session-index.md", "Session Index", ["| <Add wikilink> | <Purpose> |"]],
+	];
+	for (const [filename, heading, rows] of indexSpecs) {
+		writeGeneratedFile(packPath, `00-system/indexes/${filename}`, `---
 type: index
-id: index.${packSlug}.context-index
-title: Context Index
+id: index.${packSlug}.${filename.replace(/\.md$/, "")}
+title: ${heading}
 status: active
 source_of_truth: true
 freshness: current
@@ -809,15 +1406,13 @@ tags:
   - pack/${packSlug}
 ---
 
-# Context Index
+# ${heading}
 
 | Note | Use |
 |---|---|
-${contextEntries.join("\n")}
-`;
-	const contextIndexPath = path.join(packPath, "00-system/indexes/context-index.md");
-	fs.writeFileSync(contextIndexPath, contextIndexContent);
-	filesCreated.push(contextIndexPath);
+${rows.join("\n")}
+`, filesCreated);
+	}
 
 	return { packPath, filesCreated };
 }
@@ -834,16 +1429,26 @@ export function _setVaultRoot(root: string) {
 export function _setActivePack(pack: string, packPath: string) {
 	activePack = pack;
 	activePackPath = packPath;
+	qmdCollection = `memctx-${pack}`;
 }
 export function _setQmdAvailable(available: boolean) {
 	qmdAvailable = available;
+	qmdBin = available ? (qmdBin || "qmd") : "";
+	qmdStatus = available ? { available: true, bin: qmdBin, source: "path" } : { available: false, source: "missing" };
+}
+export function _setStrictMode(enabled: boolean) {
+	strictMode = enabled;
 }
 export function _resetState() {
 	vaultRoot = "";
 	activePack = "";
 	activePackPath = "";
 	qmdAvailable = false;
+	qmdBin = "";
+	qmdStatus = { available: false, source: "missing" };
 	qmdCollection = "";
+	strictMode = parseBooleanEnv(process.env.MEMCTX_STRICT);
+	lastRetrieval = null;
 	_packsDir = "";
 }
 
@@ -891,8 +1496,10 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		if (ctx.hasUI) {
-			const qmdStatus = qmdAvailable ? "qmd ✓" : "qmd ✗ (keyword search only)";
-			ctx.ui.notify(`memctx: Pack "${activePack}" loaded. ${qmdStatus}`, "info");
+			const qmdLabel = qmdAvailable
+				? `qmd ✓ (${qmdStatus.source})`
+				: "qmd ✗ (grep fallback)";
+			ctx.ui.notify(`memctx: Pack "${activePack}" loaded. ${qmdLabel}`, "info");
 			ctx.ui.setStatus("memctx", `📦 ${activePack}`);
 		}
 	});
@@ -901,23 +1508,50 @@ export default function (pi: ExtensionAPI) {
 	pi.on("before_agent_start", async (event, _ctx) => {
 		if (!activePackPath) return;
 
-		// Semantic search for relevant memories
 		let searchResults = "";
-		if (qmdAvailable && event.prompt) {
-			const sanitized = (event.prompt ?? "").replace(/[^\w\s.,?!-]/g, "").slice(0, 200);
-			if (sanitized.trim()) {
-				searchResults = await qmdSearch(sanitized, qmdCollection, 3);
-			}
+		let retrievalMode: RetrievalStatus["mode"] = "none";
+		let resultCount = 0;
+		const sanitized = (event.prompt ?? "").replace(/[^\w\s.,?!-]/g, "").slice(0, 240).trim();
+
+		if (sanitized) {
+			const retrieval = await searchPackMemory(activePackPath, sanitized, 3, qmdAvailable ? "semantic" : "keyword");
+			searchResults = retrieval.text;
+			retrievalMode = retrieval.mode;
+			resultCount = retrieval.matchCount;
 		}
+
+		lastRetrieval = {
+			prompt: truncate(event.prompt ?? "", 200),
+			mode: retrievalMode,
+			query: sanitized,
+			resultCount,
+			timestamp: nowTimestamp(),
+		};
 
 		const packContext = buildPackContext(activePackPath, searchResults);
 		if (!packContext) return;
 
+		const memoryGate = [
+			"## Memory Gate",
+			"For project-specific questions:",
+			"1. Use the loaded memory context first.",
+			"2. If relevant facts may exist outside the injected context, call memctx_search before answering.",
+			"3. If memory is insufficient or conflicts with source files, inspect source-of-truth files.",
+			"4. If you discover durable safe knowledge, save or suggest saving it with memctx_save.",
+			"5. Never save secrets, credentials, private keys, tokens, customer data, or sensitive payloads.",
+			strictMode
+				? "6. Strict mode is ON: before final answers for project-specific prompts, call memctx_search unless the answer is fully supported by injected memory context."
+				: "",
+		].filter(Boolean).join("\n");
+
 		const injection = [
 			"\n\n## Memory Context",
 			`Active pack: \`${activePack}\``,
+			`Retrieval: ${retrievalMode} (${resultCount} result${resultCount === 1 ? "" : "s"})`,
 			"The following memory context has been loaded from the pack.",
 			"Use the memctx_search tool to find additional context across pack files.",
+			"",
+			memoryGate,
 			"",
 			packContext,
 		].join("\n");
@@ -979,6 +1613,54 @@ export default function (pi: ExtensionAPI) {
 	// --- session_shutdown: cleanup ---
 	pi.on("session_shutdown", async (_event, _ctx) => {
 		// Nothing to flush at the moment
+	});
+
+	// --- /pack-status command: show active pack and retrieval state ---
+	pi.registerCommand("pack-status", {
+		description: "Show active memory pack, qmd, retrieval, and strict-mode status.",
+		handler: async (_args, ctx) => {
+			const packsDir = _packsDir || (vaultRoot ? path.join(vaultRoot, "packs") : "");
+			const packFileCount = activePackPath ? scanPackFiles(activePackPath).length : 0;
+			const retrieval = lastRetrieval
+				? [
+					`Last retrieval: ${lastRetrieval.mode}`,
+					`  query: ${lastRetrieval.query || "<none>"}`,
+					`  results: ${lastRetrieval.resultCount}`,
+					`  at: ${lastRetrieval.timestamp}`,
+				]
+				: ["Last retrieval: none"];
+			const lines = [
+				`Active pack: ${activePack || "<none>"}`,
+				`Pack path: ${activePackPath || "<none>"}`,
+				`Packs dir: ${packsDir || "<none>"}`,
+				`Pack files: ${packFileCount} markdown files`,
+				`qmd: ${qmdStatus.available ? "available" : "unavailable"}`,
+				`qmd source: ${qmdStatus.source}`,
+				`qmd bin: ${qmdStatus.bin ?? "<none>"}`,
+				`qmd version: ${qmdStatus.version ?? "<unknown>"}`,
+				`qmd collection: ${qmdCollection || "<none>"}`,
+				`Strict mode: ${strictMode ? "on" : "off"}`,
+				...retrieval,
+			];
+			ctx.ui.notify(lines.join("\n"), "info");
+		},
+	});
+
+	// --- /memctx-strict command: toggle strict memory gate ---
+	pi.registerCommand("memctx-strict", {
+		description: "Toggle strict memory retrieval guidance. Usage: /memctx-strict [on|off|status]",
+		handler: async (args, ctx) => {
+			const target = (args ?? "status").trim().toLowerCase();
+			if (["on", "true", "1", "yes"].includes(target)) {
+				strictMode = true;
+			} else if (["off", "false", "0", "no"].includes(target)) {
+				strictMode = false;
+			} else if (target && target !== "status") {
+				ctx.ui.notify("memctx: Usage: /memctx-strict [on|off|status]", "error");
+				return;
+			}
+			ctx.ui.notify(`memctx: Strict mode ${strictMode ? "on" : "off"}.`, "info");
+		},
 	});
 
 	// --- /pack command: list and switch packs ---
@@ -1154,42 +1836,10 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const { query, mode = "keyword", limit = 5 } = params;
+			const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+			const search = await searchPackMemory(activePackPath, query, limit, mode as SearchMode);
 
-			// Try qmd first
-			if (qmdAvailable) {
-				const results = await qmdSearch(query, qmdCollection, limit, mode as any);
-				if (results) {
-					return {
-						content: [{ type: "text" as const, text: results }],
-						details: { mode, collection: qmdCollection },
-					};
-				}
-			}
-
-			// Fallback: grep-based search
-			const files = scanPackFiles(activePackPath);
-			const matches: string[] = [];
-			const queryLower = query.toLowerCase();
-			const terms = queryLower.split(/\s+/).filter(Boolean);
-
-			for (const f of files) {
-				if (matches.length >= limit) break;
-				const content = readFileSafe(f);
-				if (!content) continue;
-				const contentLower = content.toLowerCase();
-				const score = terms.filter((t) => contentLower.includes(t)).length;
-				if (score > 0) {
-					const rel = path.relative(activePackPath, f);
-					// Extract matching lines
-					const lines = content.split("\n");
-					const matchingLines = lines
-						.filter((line) => terms.some((t) => line.toLowerCase().includes(t)))
-						.slice(0, 5);
-					matches.push(`### ${rel} (${score}/${terms.length} terms matched)\n${matchingLines.join("\n")}`);
-				}
-			}
-
-			if (matches.length === 0) {
+			if (search.matchCount === 0) {
 				// Try cross-pack search to suggest the right pack
 				const packsDir = _packsDir || path.join(vaultRoot, "packs");
 				const allPacks = listPacks(packsDir);
@@ -1219,18 +1869,21 @@ export default function (pi: ExtensionAPI) {
 						type: "text" as const,
 						text: `No results for "${query}" in pack "${activePack}".${hint}`,
 					}],
-					details: { mode: qmdAvailable ? mode : "grep-fallback", crossPackHints: crossResults },
+					details: { mode: search.mode, crossPackHints: crossResults },
 				};
 			}
 
+			const header = search.mode === "qmd"
+				? `## Search results (qmd ${mode})`
+				: "## Search results (grep fallback)";
 			return {
 				content: [
 					{
 						type: "text" as const,
-						text: `## Search results (grep fallback, qmd not available)\n\n${matches.join("\n\n")}`,
+						text: `${header}\n\n${search.text}`,
 					},
 				],
-				details: { mode: "grep-fallback", matchCount: matches.length },
+				details: { mode: search.mode, matchCount: search.matchCount, collection: qmdCollection },
 			};
 		},
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5019,9 +5019,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.10.tgz",
+      "integrity": "sha512-zL1BOcqQ9V2Fsm/UFRP6MpJAWtLrTh1YSK3Ie9OEPuXt347P6J1UiotM71Dkhj6/pmitBnS02TSbK28iXaS+Pg==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,26 @@
 {
   "name": "pi-memctx",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.49"
+      },
       "devDependencies": {
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*",
-        "@sinclair/typebox": "*",
         "@types/bun": "^1.3.13"
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@tobilu/qmd": "^2.1.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -879,6 +884,59 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.8.tgz",
+      "integrity": "sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
@@ -1194,6 +1252,47 @@
         "zod-to-json-schema": "^3.25.0"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1206,6 +1305,256 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@node-llama-cpp/linux-arm64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.18.1.tgz",
+      "integrity": "sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-armv7l": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-armv7l/-/linux-armv7l-3.18.1.tgz",
+      "integrity": "sha512-BrJL2cGo0pN5xd5nw+CzTn2rFMpz9MJyZZPUY81ptGkF2uIuXT2hdCVh56i9ImQrTwBfq1YcZL/l/Qe/1+HR/Q==",
+      "cpu": [
+        "arm",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64/-/linux-x64-3.18.1.tgz",
+      "integrity": "sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.18.1.tgz",
+      "integrity": "sha512-qOaYP4uwsUoBHQ/7xSOvyJIuXapS57Al+Sudgi00f96ldNZLKe1vuSGptAi5LTM2lIj66PKm6h8PlRWctwsZ2g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.18.1.tgz",
+      "integrity": "sha512-VqyKhAVHPCpFzh0f1koCBgpThL+04QOXwv0oDQ8s8YcpfMMOXQlBhTB0plgTh0HrPExoObfTS4ohkrbyGgmztQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-vulkan": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.18.1.tgz",
+      "integrity": "sha512-SIaNTK5pUPhwJD0gmiQfHa8OrRctVMmnqu+slJrz2Mzgg/XrwFndJlS9hvc+jSjTXCouwf7sYeQaaJWvQgBh/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-arm64-metal": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-arm64-metal/-/mac-arm64-metal-3.18.1.tgz",
+      "integrity": "sha512-cyZTdsUMlvuRlGmkkoBbN3v/DT6NuruEqoQYd9CqIrPyLa1xLNBTSKIZ9SgRnw23iCOj4URfITvRP+2pu63LuQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-x64/-/mac-x64-3.18.1.tgz",
+      "integrity": "sha512-GfCPgdltaIpBhEnQ7WfsrRXrZO9r9pBtDUAQMXRuJwOPP5q7xKrQZUXI6J6mpc8tAG0//CTIuGn4hTKoD/8V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-arm64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-arm64/-/win-arm64-3.18.1.tgz",
+      "integrity": "sha512-S05YUzBMVSRS5KNbOS26cDYugeQHqogI3uewtTUBVC0tPbTHRSKjsdicmgWru1eNAry399LWWhzOf/3St/qsAw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64/-/win-x64-3.18.1.tgz",
+      "integrity": "sha512-QLDVphPl+YDI+x/VYYgIV1N9g0GMXk3PqcoopOUG3cBRUtce7FO+YX903YdRJezs4oKbIp8YaO+xYBgeUSqhpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.18.1.tgz",
+      "integrity": "sha512-drgJmBhnxGQtB/SLo4sf4PPSuxRv3MdNP0FF6rKPY9TtzEOV293bRQyYEu/JYwvXfVApAIsRaJUTGvCkA9Qobw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda-ext": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.18.1.tgz",
+      "integrity": "sha512-u0FzJBQsJA355ksKERxwPJhlcWl3ZJSNkU2ZUwDEiKNOCbv3ybvSCIEyDvB63wdtkfVUuCRJWijZnpDZxrCGqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-vulkan": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.18.1.tgz",
+      "integrity": "sha512-PjmxrnPToi7y0zlP7l+hRIhvOmuEv94P6xZ11vjqICEJu8XdAJpvTfPKgDW4W0p0v4+So8ZiZYLUuwIHcsseyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1281,6 +1630,154 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@reflink/reflink": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
+      "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink-darwin-arm64": "0.1.19",
+        "@reflink/reflink-darwin-x64": "0.1.19",
+        "@reflink/reflink-linux-arm64-gnu": "0.1.19",
+        "@reflink/reflink-linux-arm64-musl": "0.1.19",
+        "@reflink/reflink-linux-x64-gnu": "0.1.19",
+        "@reflink/reflink-linux-x64-musl": "0.1.19",
+        "@reflink/reflink-win32-arm64-msvc": "0.1.19",
+        "@reflink/reflink-win32-x64-msvc": "0.1.19"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-arm64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
+      "integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-x64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
+      "integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
+      "integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
+      "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
+      "integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
+      "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-arm64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
+      "integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-x64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
+      "integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
@@ -1288,11 +1785,27 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@smithy/config-resolver": {
@@ -1977,6 +2490,68 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tinyhttp/content-disposition": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
+      "integrity": "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
+      }
+    },
+    "node_modules/@tobilu/qmd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tobilu/qmd/-/qmd-2.1.0.tgz",
+      "integrity": "sha512-oOuCoiWL9R2urgj0C336Qpv8qpq1SHhx80Vg5cQo+QRB26XPXqy7MTg/CWS6WAe6ruvVul7kEv21M5YhRzreAw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "better-sqlite3": "12.8.0",
+        "fast-glob": "3.3.3",
+        "node-llama-cpp": "3.18.1",
+        "picomatch": "4.0.4",
+        "sqlite-vec": "0.1.9",
+        "web-tree-sitter": "0.26.7",
+        "yaml": "2.8.3",
+        "zod": "4.2.1"
+      },
+      "bin": {
+        "qmd": "bin/qmd"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9",
+        "tree-sitter-go": "0.23.4",
+        "tree-sitter-python": "0.23.4",
+        "tree-sitter-rust": "0.24.0",
+        "tree-sitter-typescript": "0.23.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@tobilu/qmd/node_modules/zod": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
+      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -2054,6 +2629,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2064,11 +2653,59 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2081,7 +2718,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2113,6 +2750,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2127,7 +2774,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2154,6 +2801,21 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -2162,6 +2824,53 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bowser": {
@@ -2182,6 +2891,44 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -2211,17 +2958,107 @@
         "@types/node": "*"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chmodrp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chmodrp/-/chmodrp-1.0.2.tgz",
+      "integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-highlight": {
@@ -2263,6 +3100,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2298,11 +3148,128 @@
         "node": ">=8"
       }
     },
+    "node_modules/cmake-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-8.0.0.tgz",
+      "integrity": "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fs-extra": "^11.3.3",
+        "node-api-headers": "^1.8.0",
+        "rc": "1.2.8",
+        "semver": "^7.7.3",
+        "tar": "^7.5.6",
+        "url-join": "^4.0.1",
+        "which": "^6.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cmake-js/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmake-js/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cmake-js/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cmake-js/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmake-js/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2315,8 +3282,95 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -2332,7 +3386,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2344,6 +3398,32 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/degenerator": {
@@ -2361,6 +3441,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -2369,6 +3469,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -2381,32 +3496,99 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-var": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
+      "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -2464,6 +3646,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2491,6 +3752,47 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.5",
@@ -2528,6 +3830,16 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fd-slicer": {
@@ -2583,6 +3895,77 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2594,6 +3977,58 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -2630,7 +4065,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2640,13 +4075,52 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2690,6 +4164,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -2706,6 +4187,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/google-auth-library": {
@@ -2736,11 +4230,24 @@
         "node": ">=14"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2751,6 +4258,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/highlight.js": {
@@ -2774,6 +4307,27 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2804,11 +4358,28 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2829,11 +4400,25 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.1.1",
@@ -2845,14 +4430,230 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipull": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.5.tgz",
+      "integrity": "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tinyhttp/content-disposition": "^2.2.0",
+        "async-retry": "^1.3.3",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "commander": "^10.0.0",
+        "eventemitter3": "^5.0.1",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.1.1",
+        "is-unicode-supported": "^2.0.0",
+        "lifecycle-utils": "^2.0.1",
+        "lodash.debounce": "^4.0.8",
+        "lowdb": "^7.0.1",
+        "pretty-bytes": "^6.1.0",
+        "pretty-ms": "^8.0.0",
+        "sleep-promise": "^9.1.0",
+        "slice-ansi": "^7.1.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.1.0"
+      },
+      "bin": {
+        "ipull": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/ido-pluto/ipull?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink": "^0.1.16"
+      }
+    },
+    "node_modules/ipull/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ipull/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/lifecycle-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.1.0.tgz",
+      "integrity": "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ipull/node_modules/parse-ms": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/pretty-ms": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "parse-ms": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/json-bigint": {
@@ -2877,6 +4678,33 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jwa": {
@@ -2914,12 +4742,59 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
+    "node_modules/lifecycle-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.1.tgz",
+      "integrity": "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/lowdb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
+      "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "steno": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/lru-cache": {
       "version": "11.3.5",
@@ -2944,11 +4819,81 @@
         "node": ">= 18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2958,7 +4903,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -2969,6 +4914,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2987,21 +4958,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3016,6 +5017,42 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/netmask": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
@@ -3025,6 +5062,36 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.8.0.tgz",
+      "integrity": "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -3066,24 +5133,243 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-llama-cpp": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/node-llama-cpp/-/node-llama-cpp-3.18.1.tgz",
+      "integrity": "sha512-w0zfuy/IKS2fhrbed5SylZDXJHTVz4HnkwZ4UrFPgSNwJab3QIPwIl4lyCKHHy9flLrtxsAuV5kXfH3HZ6bb8w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "async-retry": "^1.3.3",
+        "bytes": "^3.1.2",
+        "chalk": "^5.6.2",
+        "chmodrp": "^1.0.2",
+        "cmake-js": "^8.0.0",
+        "cross-spawn": "^7.0.6",
+        "env-var": "^7.5.0",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.3.4",
+        "ignore": "^7.0.4",
+        "ipull": "^3.9.5",
+        "is-unicode-supported": "^2.1.0",
+        "lifecycle-utils": "^3.1.1",
+        "log-symbols": "^7.0.1",
+        "nanoid": "^5.1.6",
+        "node-addon-api": "^8.6.0",
+        "ora": "^9.3.0",
+        "pretty-ms": "^9.3.0",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.7.1",
+        "simple-git": "^3.33.0",
+        "slice-ansi": "^8.0.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.2.0",
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "nlc": "dist/cli/cli.js",
+        "node-llama-cpp": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/giladgd"
+      },
+      "optionalDependencies": {
+        "@node-llama-cpp/linux-arm64": "3.18.1",
+        "@node-llama-cpp/linux-armv7l": "3.18.1",
+        "@node-llama-cpp/linux-x64": "3.18.1",
+        "@node-llama-cpp/linux-x64-cuda": "3.18.1",
+        "@node-llama-cpp/linux-x64-cuda-ext": "3.18.1",
+        "@node-llama-cpp/linux-x64-vulkan": "3.18.1",
+        "@node-llama-cpp/mac-arm64-metal": "3.18.1",
+        "@node-llama-cpp/mac-x64": "3.18.1",
+        "@node-llama-cpp/win-arm64": "3.18.1",
+        "@node-llama-cpp/win-x64": "3.18.1",
+        "@node-llama-cpp/win-x64-cuda": "3.18.1",
+        "@node-llama-cpp/win-x64-cuda-ext": "3.18.1",
+        "@node-llama-cpp/win-x64-vulkan": "3.18.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/openai": {
@@ -3106,6 +5392,59 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-retry": {
@@ -3156,6 +5495,19 @@
         "node": ">= 14"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -3180,6 +5532,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
@@ -3203,6 +5565,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -3220,6 +5592,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3227,11 +5610,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -3243,7 +5706,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3272,6 +5735,20 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/proxy-agent": {
@@ -3315,38 +5792,224 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3363,12 +6026,303 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/sleep-promise": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
+      "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -3422,6 +6376,95 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optional": true,
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -3429,11 +6472,101 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdout-update": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stdout-update/-/stdout-update-4.0.1.tgz",
+      "integrity": "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-escapes": "^6.2.0",
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/stdout-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stdout-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stdout-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/steno": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
+      "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -3448,7 +6581,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3458,7 +6591,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -3471,7 +6604,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -3481,6 +6614,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strnum": {
@@ -3526,6 +6669,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3549,6 +6746,29 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
@@ -3568,6 +6788,107 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tree-sitter-go": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
+      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.23.4.tgz",
+      "integrity": "sha512-MbmUAl7y5UCUWqHscHke7DdRDwQnVNMNKQYQc4Gq2p09j+fgPxaU8JVsuOI/0HD3BSEEe5k9j3xmdtIWbDtDgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-rust": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.24.0.tgz",
+      "integrity": "sha512-NWemUDf629Tfc90Y0Z55zuwPCAHkLxWnMf2RznYu4iBkkrQl2o/CHGB7Cr52TyN5F1DAx8FmUnDtCy9iUkXZEQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -3581,6 +6902,34 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typebox": {
       "version": "1.1.35",
@@ -3619,6 +6968,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/uuid": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
@@ -3633,6 +7016,26 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -3643,11 +7046,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.7.tgz",
+      "integrity": "sha512-KiZhelTvBA/ziUHEO7Emb75cGVAq8iGZNabYaZm53Zpy50NsXyOW+xSHlwHt5CVg/TRPZBfeVLTTobF0LjFJ1w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3665,7 +7091,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3675,7 +7101,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -3688,7 +7114,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -3717,17 +7143,27 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -3783,7 +7219,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3796,7 +7232,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -3807,7 +7243,7 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*",
-        "@types/bun": "^1.3.13"
+        "@types/bun": "^1.3.13",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=20"
@@ -6937,6 +6938,21 @@
       "integrity": "sha512-kB3HoCOAE+cJ+xMCBKDsnlRJ5Fh39cIXBQ29vcqsN9+AVxCKa0qA84SDkDM51hrBOAkmAyYTpfFBdi6RzbfATA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",
@@ -51,7 +51,8 @@
   "devDependencies": {
     "@mariozechner/pi-ai": "*",
     "@mariozechner/pi-coding-agent": "*",
-    "@types/bun": "^1.3.13"
+    "@types/bun": "^1.3.13",
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "test": "bun test test/",

--- a/package.json
+++ b/package.json
@@ -33,19 +33,30 @@
     "index.ts",
     "README.md",
     "LICENSE",
+    "CHANGELOG.md",
+    "docs",
     "benchmark/"
   ],
   "pi": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.49"
+  },
+  "optionalDependencies": {
+    "@tobilu/qmd": "^2.1.0"
   },
   "devDependencies": {
     "@mariozechner/pi-ai": "*",
     "@mariozechner/pi-coding-agent": "*",
-    "@sinclair/typebox": "*"
+    "@types/bun": "^1.3.13"
   },
   "scripts": {
     "test": "bun test test/",
     "test:e2e": "bun run test/e2e.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "ci": "npm run typecheck && npm test && npm run test:e2e"
   }
 }

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -15,12 +15,14 @@ import {
 	_resetState,
 	_setActivePack,
 	_setQmdAvailable,
+	_setStrictMode,
 	_setVaultRoot,
 	buildNote,
 	buildPackContext,
 	buildSessionHandoff,
 	detectActivePack,
 	findVaultRoot,
+	generatePackFromDirectory,
 	listPacks,
 	nowTimestamp,
 	readFileSafe,
@@ -818,6 +820,16 @@ describe("extension registration", () => {
 		expect(commands["pack"]).toBeDefined();
 		expect(commands["pack"].description).toContain("switch");
 	});
+
+	test("registers /pack-status and /memctx-strict commands", () => {
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+
+		expect(commands["pack-status"]).toBeDefined();
+		expect(commands["pack-status"].description).toContain("status");
+		expect(commands["memctx-strict"]).toBeDefined();
+		expect(commands["memctx-strict"].description).toContain("strict");
+	});
 });
 
 // ==========================================================================
@@ -976,6 +988,39 @@ describe("before_agent_start context injection", () => {
 		)) as any;
 
 		expect(result.systemPrompt).toContain("memctx_search");
+	});
+
+	test("uses grep fallback retrieval during context injection when qmd is unavailable", async () => {
+		const { packPath } = createTestVault();
+		const { pi, hooks } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		_setQmdAvailable(false);
+
+		const result = (await hooks["before_agent_start"](
+			{ prompt: "PostgreSQL database", systemPrompt: "" },
+			createMockCtx(),
+		)) as any;
+
+		expect(result.systemPrompt).toContain("Retrieval: grep-fallback");
+		expect(result.systemPrompt).toContain("Relevant Memory");
+		expect(result.systemPrompt).toContain("PostgreSQL");
+	});
+
+	test("injects Memory Gate and strict-mode guidance", async () => {
+		const { packPath } = createTestVault();
+		const { pi, hooks } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		_setStrictMode(true);
+
+		const result = (await hooks["before_agent_start"](
+			{ prompt: "what stack do we use?", systemPrompt: "" },
+			createMockCtx(),
+		)) as any;
+
+		expect(result.systemPrompt).toContain("Memory Gate");
+		expect(result.systemPrompt).toContain("Strict mode is ON");
 	});
 });
 
@@ -1271,7 +1316,66 @@ describe("memctx_save tool", () => {
 });
 
 // ==========================================================================
-// 15. Integration: full flow
+// 15. pack-generate deterministic discovery
+// ==========================================================================
+
+describe("pack-generate deterministic discovery", () => {
+	beforeEach(setupTmpDir);
+	afterEach(cleanupTmpDir);
+
+	test("generates rich pack from workspace discovery", () => {
+		const scanDir = path.join(tmpDir, "workspace");
+		const packsDir = path.join(tmpDir, "packs");
+		fs.mkdirSync(path.join(scanDir, ".github", "profile"), { recursive: true });
+		fs.writeFileSync(path.join(scanDir, ".github", "profile", "README.md"), "# Org\n\nPublic organization profile.");
+
+		const nodeRepo = path.join(scanDir, "node-app");
+		fs.mkdirSync(path.join(nodeRepo, ".github", "workflows"), { recursive: true });
+		fs.writeFileSync(path.join(nodeRepo, "package.json"), JSON.stringify({
+			name: "node-app",
+			description: "Node app description",
+			scripts: { dev: "next dev", build: "next build", test: "vitest", deploy: "danger" },
+			dependencies: { next: "latest", react: "latest" },
+		}, null, 2));
+		fs.writeFileSync(path.join(nodeRepo, "README.md"), "# Node App\n\nA generated Node application.");
+		fs.writeFileSync(path.join(nodeRepo, "AGENTS.md"), "# Agents\n\nRun tests before changes.");
+		fs.writeFileSync(path.join(nodeRepo, ".github", "workflows", "ci.yml"), "name: CI\non: [push]\njobs: {}\n");
+		fs.writeFileSync(path.join(nodeRepo, ".env"), "API_KEY=super-secret-value");
+
+		const goRepo = path.join(scanDir, "go-service");
+		fs.mkdirSync(goRepo, { recursive: true });
+		fs.writeFileSync(path.join(goRepo, "go.mod"), "module example.com/go-service\n\ngo 1.22\n");
+
+		const emptyRepo = path.join(scanDir, "empty-repo");
+		fs.mkdirSync(path.join(emptyRepo, ".git"), { recursive: true });
+
+		const result = generatePackFromDirectory(scanDir, "workspace", packsDir);
+		expect(result.filesCreated.length).toBeGreaterThan(15);
+		expect(fs.existsSync(path.join(result.packPath, "20-context", "github-profile.md"))).toBe(true);
+		expect(fs.existsSync(path.join(result.packPath, "20-context", "node-app.md"))).toBe(true);
+		expect(fs.existsSync(path.join(result.packPath, "30-projects", "node-app.md"))).toBe(true);
+		expect(fs.existsSync(path.join(result.packPath, "70-runbooks", "node-app-development.md"))).toBe(true);
+		expect(fs.existsSync(path.join(result.packPath, "70-runbooks", "go-service-development.md"))).toBe(true);
+
+		const resourceMap = fs.readFileSync(path.join(result.packPath, "00-system", "pi-agent", "resource-map.md"), "utf-8");
+		expect(resourceMap).toContain(".github");
+		expect(resourceMap).toContain("node-app");
+		expect(resourceMap).toContain("go-service");
+		expect(resourceMap).toContain("empty-repo");
+		expect(resourceMap).toContain("placeholder");
+
+		const nodeContext = fs.readFileSync(path.join(result.packPath, "20-context", "node-app.md"), "utf-8");
+		expect(nodeContext).toContain("Node app description");
+		expect(nodeContext).toContain("npm run build");
+		expect(nodeContext).toContain("ci.yml");
+		expect(nodeContext).not.toContain("super-secret-value");
+		expect(nodeContext).not.toContain("API_KEY");
+		expect(nodeContext).not.toContain("npm run deploy");
+	});
+});
+
+// ==========================================================================
+// 16. Integration: full flow
 // ==========================================================================
 
 describe("integration: full flow", () => {


### PR DESCRIPTION
## Summary
- resolve qmd from MEMCTX_QMD_BIN, PATH, or optional bundled @tobilu/qmd with grep fallback
- add /pack-status, /memctx-strict, Memory Gate, and prompt-specific retrieval fallback in before_agent_start
- upgrade /pack-generate with deterministic workspace discovery, full pack structure, context/project/observation/runbook notes, indexes, safe command extraction, and redaction
- document pack generation, qmd resolution, status, and strict mode

## Tests
- npm test
- npm run test:e2e
- npm pack --dry-run --json

## Known follow-up
- npm run typecheck / tsc --noEmit timed out in this environment after dependency install; unit and e2e tests pass.