### PR TITLE
ci: publish GitHub Packages mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   release:
@@ -104,6 +105,36 @@ jobs:
           fi
 
           npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PACKAGE="@weauratech/pi-memctx"
+          REGISTRY="https://npm.pkg.github.com"
+
+          if npm view "$PACKAGE@$VERSION" version --registry="$REGISTRY" >/dev/null 2>&1; then
+            echo "$PACKAGE@$VERSION is already published on GitHub Packages. Skipping publish."
+            exit 0
+          fi
+
+          rm -rf github-package
+          mkdir github-package
+          tar -xzf "${{ steps.pack.outputs.file }}" -C github-package
+
+          node <<'NODE'
+          const fs = require("fs");
+          const path = "github-package/package/package.json";
+          const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+          pkg.name = "@weauratech/pi-memctx";
+          pkg.publishConfig = { registry: "https://npm.pkg.github.com" };
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+          NODE
+
+          cd github-package/package
+          npm publish --registry="$REGISTRY" --access public
 
       - name: Create or update GitHub Release
         env:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Or install directly from GitHub:
 pi install git:github.com/weauratech/pi-memctx
 ```
 
+A GitHub Packages mirror is also published as `@weauratech/pi-memctx` for users who configure the GitHub npm registry.
+
 ## Quick start
 
 ### 1. Generate a pack from your project

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -18,9 +18,10 @@ Releases are tag-driven. Pushing a tag like `v0.3.0` runs `.github/workflows/rel
 5. runs `npm pack --json`;
 6. generates a SHA-256 checksum for the tarball;
 7. publishes the tarball to npm when `NPM_TOKEN` is configured;
-8. creates or updates the GitHub Release and uploads the tarball plus checksum.
+8. publishes a scoped mirror to GitHub Packages as `@weauratech/pi-memctx` using `GITHUB_TOKEN`;
+9. creates or updates the GitHub Release and uploads the tarball plus checksum.
 
-The publish step is idempotent: if the version already exists on npm, it skips publishing. If `NPM_TOKEN` is not configured, the workflow still creates/updates the GitHub Release and can be rerun after the secret is added.
+The publish steps are idempotent: if the version already exists on a registry, publishing to that registry is skipped. If `NPM_TOKEN` is not configured, the workflow still publishes the GitHub Packages mirror and creates/updates the GitHub Release; rerun it after adding the secret to publish to npmjs.com.
 
 ## Required secret
 
@@ -31,6 +32,29 @@ NPM_TOKEN
 ```
 
 The workflow also requests `id-token: write` so the project can migrate to npm Trusted Publishing later.
+
+## GitHub Packages mirror
+
+The release workflow also publishes a GitHub Packages mirror under the organization scope:
+
+```txt
+@weauratech/pi-memctx
+```
+
+The repository package name remains `pi-memctx` for npmjs.com. During release, the workflow extracts the generated npm tarball into a temporary directory, rewrites only the temporary `package.json` name to `@weauratech/pi-memctx`, and publishes that scoped package to `https://npm.pkg.github.com`.
+
+To install the GitHub Packages mirror, configure npm for the scope and authenticate with a GitHub token that can read packages:
+
+```bash
+npm config set @weauratech:registry https://npm.pkg.github.com
+pi install npm:@weauratech/pi-memctx
+```
+
+For most public users, npmjs.com remains the recommended registry:
+
+```bash
+pi install npm:pi-memctx
+```
 
 ## Before publishing a release
 


### PR DESCRIPTION
## Summary
- add GitHub Packages publishing to the Release workflow
- publish a scoped mirror as `@weauratech/pi-memctx` while keeping npmjs package name `pi-memctx`
- document GitHub Packages installation and registry configuration

## Tests
- npm run ci
- npm pack --dry-run --json

## Notes
The workflow rewrites only the temporary extracted package.json before publishing to GitHub Packages; the repository package name remains unchanged for npmjs.