### PR TITLE
ci: write GitHub Packages auth to npm userconfig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,11 @@ jobs:
           PACKAGE="@weauratech/pi-memctx"
           REGISTRY="https://npm.pkg.github.com"
 
-          cat > ~/.npmrc <<EOF
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          cat >> "$NPMRC" <<EOF
           @weauratech:registry=$REGISTRY
           //npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN
+          always-auth=true
           EOF
 
           if npm view "$PACKAGE@$VERSION" version --registry="$REGISTRY" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- append GitHub Packages auth to the active npm userconfig used by setup-node
- keeps scoped package publishing for @weauratech/pi-memctx authenticated with GITHUB_TOKEN

## Tests
- npm run ci
- npm pack --dry-run --json