### PR TITLE
docs: document LLM modes and deep pack generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,25 +266,33 @@ These slash commands are available inside Pi after the extension loads.
 | Command | Usage | What |
 |---|---|---|
 | `/pack` | `/pack` or `/pack <name>` | List packs with a picker or switch directly. |
-| `/pack-status` | `/pack-status` | Show active pack, pack path, qmd status/source/bin/error, qmd collection, strict mode, file count, and last retrieval. |
+| `/pack-status` | `/pack-status` | Show active pack, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
 | `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. In strict mode, project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
-| `/pack-generate` | `/pack-generate [path] [slug]` | Generate a structured pack from a directory of repositories. |
+| `/memctx-auto-switch` | `/memctx-auto-switch off\|cwd\|prompt\|all\|status` | Configure cwd/prompt-based automatic pack switching. |
+| `/memctx-llm` | `/memctx-llm off\|assist\|first\|status` | Configure LLM assistance for prompt pack switching and pack generation. |
+| `/pack-generate` | `/pack-generate [path] [slug]` | Generate a structured pack from a directory of repositories, with optional LLM deep enrichment. |
 
 ### `/pack-status` example
 
 ```txt
 Active pack: opensource
 Pack path: ~/.pi/agent/memory-vault/packs/opensource
-qmd: unavailable
+Auto-switch: cwd
+Selection: high (112)
+Last switch: none
+qmd: available
 qmd source: local-dependency
-qmd error: probe timed out
 Strict mode: off
-Last retrieval: grep-fallback
+LLM mode: assist
+LLM calls: 0
+Last retrieval: qmd
 ```
 
 ### `/pack-generate` discovery
 
-`/pack-generate` now performs deterministic local discovery before writing notes. It detects normal repos, hidden allowlist repos like `.github`, Git remotes, Node/TS and Go manifests, package scripts, safe commands, GitHub Actions, read-first docs, infra hints, placeholder repos, and redacts sensitive-looking values before persistence.
+`/pack-generate` performs deterministic local discovery before writing notes. It detects normal repos, hidden allowlist repos like `.github`, Git remotes, Node/TS and Go manifests, package scripts, safe commands, GitHub Actions, read-first docs, infra hints, placeholder repos, and redacts sensitive-looking values before persistence.
+
+When `MEMCTX_LLM_MODE=assist` or `first` and a model is selected, it then asks the LLM to select important files from compact inventories and synthesize architecture notes from redacted snippets.
 
 See [Pack generation](docs/pack-generate.md) for details.
 
@@ -297,6 +305,15 @@ cd ~/code/my-api       # → loads "my-api" pack
 cd ~/code/my-infra     # → loads "infra" pack
 cd ~/code              # → loads org-level pack
 ```
+
+Switch mid-session with `/pack`, or enable prompt-based switching:
+
+```txt
+/memctx-auto-switch all
+/memctx-llm first
+```
+
+`assist` mode uses deterministic matching first and asks the LLM for ambiguous prompt decisions. `first` mode asks the LLM whenever possible while keeping deterministic validation/fallbacks.
 
 Switch mid-session with `/pack`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ Use `/pack-generate` inside a Pi session:
 /pack-generate /path/to/repos my-project
 ```
 
-The generator performs deterministic local discovery of repositories, read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints. See [Pack generation](pack-generate.md).
+The generator performs deterministic local discovery of repositories, read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints. When `MEMCTX_LLM_MODE` is enabled and a model is selected, it also performs LLM-assisted deep enrichment from selected redacted source snippets. See [Pack generation](pack-generate.md).
 
 Or create folders manually:
 
@@ -55,6 +55,20 @@ Use strict mode when you want stronger retrieval guidance before project-specifi
 
 ```txt
 /memctx-strict on
+```
+
+Configure automatic pack switching and LLM assistance:
+
+```txt
+/memctx-auto-switch all
+/memctx-llm first
+```
+
+Environment equivalents:
+
+```bash
+MEMCTX_AUTO_SWITCH=off|cwd|prompt|all
+MEMCTX_LLM_MODE=off|assist|first
 ```
 
 Ask the agent to search memory:

--- a/docs/pack-generate.md
+++ b/docs/pack-generate.md
@@ -8,9 +8,11 @@
 
 If no path is provided, pi-memctx scans the current working directory. If no slug is provided, it derives one from the scanned directory name.
 
-## Deterministic discovery
+## Hybrid discovery and LLM enrichment
 
-The generator performs local-only discovery and writes a structured pack before any future LLM enrichment step. It detects:
+The generator first performs deterministic local discovery so pack structure is always created even when no model is available. When `MEMCTX_LLM_MODE` is `assist` or `first` and a Pi model is selected, `/pack-generate` then runs token-conscious LLM enrichment.
+
+The local deterministic pass detects:
 
 - normal top-level repositories;
 - hidden repository allowlist entries such as `.github` and `.gitlab`;
@@ -20,6 +22,37 @@ The generator performs local-only discovery and writes a structured pack before 
 - infrastructure/config hints such as Docker, Terraform, Helm, Kubernetes, `infra/`, and CI workflows;
 - read-first docs such as `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, and selected `docs/**/*.md` files;
 - safe development commands from package scripts, Go manifests, and Make targets.
+
+## LLM-assisted deep enrichment
+
+When LLM enrichment is enabled, pi-memctx:
+
+1. builds a compact file inventory per active repository;
+2. asks the selected model to choose the highest-value files for architecture/API/data-model/integration understanding;
+3. extracts redacted snippets only from those selected files;
+4. asks the model to synthesize compact JSON;
+5. writes evidence-based architecture notes such as `20-context/<repo>-llm-architecture.md`;
+6. appends those notes to `00-system/indexes/context-index.md`.
+
+Token controls:
+
+- file inventory is metadata-first;
+- selected files are capped;
+- snippets are truncated;
+- sensitive filenames are skipped;
+- high-confidence secret-looking values are redacted before model use.
+
+Disable LLM use with:
+
+```bash
+MEMCTX_LLM_MODE=off
+```
+
+Prefer stronger LLM usage with:
+
+```bash
+MEMCTX_LLM_MODE=first
+```
 
 ## Generated structure
 
@@ -33,6 +66,7 @@ The generated pack uses the full memory-pack layout:
 10-user/
 20-context/overview.md
 20-context/<repo>.md
+20-context/<repo>-llm-architecture.md   # when LLM enrichment runs
 30-projects/<repo>.md
 40-actions/
 50-decisions/
@@ -49,6 +83,6 @@ The generator skips sensitive file names such as `.env`, private keys, credentia
 
 Generated notes are context, not authority. Source-of-truth repository files, tests, CI, and live runtime facts override memory.
 
-## Current limitation
+## Current limitations
 
-This phase is deterministic. LLM-assisted synthesis and `/pack-enrich` are planned as follow-up phases so generated notes can be further summarized without overwriting human-authored memory.
+LLM enrichment is intentionally evidence-bounded: it summarizes selected redacted snippets and should not be treated as source of truth. If no model is selected or no API key is available, `/pack-generate` still produces the deterministic pack and skips LLM enrichment with a warning.


### PR DESCRIPTION
## Summary
- document /memctx-auto-switch and /memctx-llm
- document MEMCTX_AUTO_SWITCH and MEMCTX_LLM_MODE
- document LLM-assisted /pack-generate flow and token/safety controls
- update /pack-status example with selection and LLM stats

## Tests
- npm run typecheck

## Merge order
This PR is stacked on PR #11. Merge #10 first, then #11, then this docs PR.