### PR TITLE
feat: standardize memctx pack commands and overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cd /path/to/your/repos
 pi -e pi-memctx
 
 # Inside pi:
-/pack-generate
+/memctx-pack-generate
 ```
 
 This performs deterministic discovery across your repos — including read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints — then builds a structured memory pack automatically.
@@ -265,14 +265,16 @@ These slash commands are available inside Pi after the extension loads.
 
 | Command | Usage | What |
 |---|---|---|
-| `/pack` | `/pack` or `/pack <name>` | List packs with a picker or switch directly. |
-| `/pack-status` | `/pack-status` | Show active pack, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
+| `/memctx-pack` | `/memctx-pack` or `/memctx-pack <name>` | List packs with a picker or switch directly. |
+| `/memctx-pack-status` | `/memctx-pack-status` | Show active pack, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
 | `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. In strict mode, project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
 | `/memctx-auto-switch` | `/memctx-auto-switch off\|cwd\|prompt\|all\|status` | Configure cwd/prompt-based automatic pack switching. |
 | `/memctx-llm` | `/memctx-llm off\|assist\|first\|status` | Configure LLM assistance for prompt pack switching and pack generation. |
-| `/pack-generate` | `/pack-generate [path] [slug]` | Generate a structured pack from a directory of repositories, with optional LLM deep enrichment. |
+| `/memctx-pack-generate` | `/memctx-pack-generate [path] [slug]` | Generate a structured pack from a directory of repositories, with optional LLM deep enrichment. |
 
-### `/pack-status` example
+Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, and `/pack-generate`.
+
+### `/memctx-pack-status` example
 
 ```txt
 Active pack: opensource
@@ -285,12 +287,13 @@ qmd source: local-dependency
 Strict mode: off
 LLM mode: assist
 LLM calls: 0
+Overlay: 📦 opensource · qmd:3 · strict:off · llm:assist
 Last retrieval: qmd
 ```
 
-### `/pack-generate` discovery
+### `/memctx-pack-generate` discovery
 
-`/pack-generate` performs deterministic local discovery before writing notes. It detects normal repos, hidden allowlist repos like `.github`, Git remotes, Node/TS and Go manifests, package scripts, safe commands, GitHub Actions, read-first docs, infra hints, placeholder repos, and redacts sensitive-looking values before persistence.
+`/memctx-pack-generate` performs deterministic local discovery before writing notes. It detects normal repos, hidden allowlist repos like `.github`, Git remotes, Node/TS and Go manifests, package scripts, safe commands, GitHub Actions, read-first docs, infra hints, placeholder repos, and redacts sensitive-looking values before persistence.
 
 When `MEMCTX_LLM_MODE=assist` or `first` and a model is selected, it then asks the LLM to select important files from compact inventories and synthesize architecture notes from redacted snippets.
 
@@ -306,7 +309,7 @@ cd ~/code/my-infra     # → loads "infra" pack
 cd ~/code              # → loads org-level pack
 ```
 
-Switch mid-session with `/pack`, or enable prompt-based switching:
+Switch mid-session with `/memctx-pack`, or enable prompt-based switching:
 
 ```txt
 /memctx-auto-switch all
@@ -315,7 +318,7 @@ Switch mid-session with `/pack`, or enable prompt-based switching:
 
 `assist` mode uses deterministic matching first and asks the LLM for ambiguous prompt decisions. `first` mode asks the LLM whenever possible while keeping deterministic validation/fallbacks.
 
-Switch mid-session with `/pack`.
+Switch mid-session with `/memctx-pack`.
 
 ## Pack locations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ memctx_save
 session_before_compact
   -> write a compact handoff action note
 
-pack-generate
+memctx-pack-generate
   -> discover repositories under the target directory
   -> collect sanitized evidence from docs, manifests, workflows, git, and safe command sources
   -> write full pack structure, resource map, context notes, project notes, observations, runbooks, and indexes
@@ -41,7 +41,7 @@ pack-generate
 - Markdown-first: memory is reviewable with normal tools.
 - Bounded context: lower-priority sections are trimmed before flooding the prompt.
 - qmd optional: semantic search is attempted automatically when available, but grep fallback remains the hard guarantee.
-- Observable memory state: `/pack-status` reports active pack, qmd resolution, and last retrieval.
+- Observable memory state: `/memctx-pack-status` reports active pack, qmd resolution, LLM mode, strict mode, and last retrieval; the footer overlay includes current `memctx-strict` and `memctx-llm` values.
 - Strict guidance is opt-in via `MEMCTX_STRICT=true` or `/memctx-strict on`.
 - Source of truth wins: repository files and live system state override memory notes.
 - Generated memory is conservative: deterministic pack generation avoids destructive commands and redacts sensitive-looking values.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,10 +20,10 @@ pi-memctx looks for packs in this order:
 
 ## Create a pack
 
-Use `/pack-generate` inside a Pi session:
+Use `/memctx-pack-generate` inside a Pi session:
 
 ```txt
-/pack-generate /path/to/repos my-project
+/memctx-pack-generate /path/to/repos my-project
 ```
 
 The generator performs deterministic local discovery of repositories, read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints. When `MEMCTX_LLM_MODE` is enabled and a model is selected, it also performs LLM-assisted deep enrichment from selected redacted source snippets. See [Pack generation](pack-generate.md).
@@ -46,10 +46,12 @@ See `examples/basic-pack/` for a minimal public-safe pack.
 ## Use a pack
 
 ```txt
-/pack
-/pack my-project
-/pack-status
+/memctx-pack
+/memctx-pack my-project
+/memctx-pack-status
 ```
+
+Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, and `/pack-generate`.
 
 Use strict mode when you want stronger retrieval guidance before project-specific answers:
 

--- a/docs/pack-generate.md
+++ b/docs/pack-generate.md
@@ -1,16 +1,18 @@
 # Pack generation
 
-`/pack-generate` creates a memory pack from a directory of repositories.
+`/memctx-pack-generate` creates a memory pack from a directory of repositories.
 
 ```txt
-/pack-generate /path/to/repos my-project
+/memctx-pack-generate /path/to/repos my-project
 ```
+
+`/pack-generate` remains available as a deprecated compatibility alias.
 
 If no path is provided, pi-memctx scans the current working directory. If no slug is provided, it derives one from the scanned directory name.
 
 ## Hybrid discovery and LLM enrichment
 
-The generator first performs deterministic local discovery so pack structure is always created even when no model is available. When `MEMCTX_LLM_MODE` is `assist` or `first` and a Pi model is selected, `/pack-generate` then runs token-conscious LLM enrichment.
+The generator first performs deterministic local discovery so pack structure is always created even when no model is available. When `MEMCTX_LLM_MODE` is `assist` or `first` and a Pi model is selected, `/memctx-pack-generate` then runs token-conscious LLM enrichment.
 
 The local deterministic pass detects:
 
@@ -85,4 +87,4 @@ Generated notes are context, not authority. Source-of-truth repository files, te
 
 ## Current limitations
 
-LLM enrichment is intentionally evidence-bounded: it summarizes selected redacted snippets and should not be treated as source of truth. If no model is selected or no API key is available, `/pack-generate` still produces the deterministic pack and skips LLM enrichment with a warning.
+LLM enrichment is intentionally evidence-bounded: it summarizes selected redacted snippets and should not be treated as source of truth. If no model is selected or no API key is available, `/memctx-pack-generate` still produces the deterministic pack and skips LLM enrichment with a warning.

--- a/docs/search.md
+++ b/docs/search.md
@@ -27,4 +27,4 @@ pi-memctx attempts to use qmd automatically:
 3. `node_modules/.bin/qmd` from the optional bundled dependency
 4. grep fallback
 
-Use `/pack-status` to see which path is active.
+Use `/memctx-pack-status` to see which path is active. `/pack-status` remains available as a deprecated compatibility alias.

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import { execFile, execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { complete, type UserMessage } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 // ---------------------------------------------------------------------------
@@ -589,9 +589,7 @@ async function maybeSwitchPackByPrompt(prompt: string, packsDir: string, ctx: Ex
 
 function buildStatusText(): string {
 	const retrieval = lastRetrieval ? `${lastRetrieval.mode}:${lastRetrieval.resultCount}` : "idle";
-	const strict = strictMode ? " strict" : "";
-	const llm = llmMode !== "off" ? ` llm:${llmStats.callsThisSession}` : "";
-	return `📦 ${activePack || "none"} · ${retrieval}${strict}${llm}`;
+	return `📦 ${activePack || "none"} · ${retrieval} · strict:${strictMode ? "on" : "off"} · llm:${llmMode}${llmStats.callsThisSession ? `(${llmStats.callsThisSession})` : ""}`;
 }
 
 export async function searchPackMemory(
@@ -2109,10 +2107,10 @@ export default function (pi: ExtensionAPI) {
 		// Nothing to flush at the moment
 	});
 
-	// --- /pack-status command: show active pack and retrieval state ---
-	pi.registerCommand("pack-status", {
-		description: "Show active memory pack, qmd, retrieval, and strict-mode status.",
-		handler: async (_args, ctx) => {
+	// --- /memctx-pack-status command: show active pack and retrieval state ---
+	const packStatusCommand = {
+		description: "Show active memory pack, qmd, retrieval, strict-mode, and LLM status. Usage: /memctx-pack-status",
+		handler: async (_args: string, ctx: ExtensionContext) => {
 			const packsDir = _packsDir || (vaultRoot ? path.join(vaultRoot, "packs") : "");
 			const packFileCount = activePackPath ? scanPackFiles(activePackPath).length : 0;
 			const retrieval = lastRetrieval
@@ -2157,6 +2155,11 @@ export default function (pi: ExtensionAPI) {
 			];
 			ctx.ui.notify(lines.join("\n"), "info");
 		},
+	};
+	pi.registerCommand("memctx-pack-status", packStatusCommand);
+	pi.registerCommand("pack-status", {
+		...packStatusCommand,
+		description: "Deprecated alias for /memctx-pack-status.",
 	});
 
 	// --- /memctx-strict command: toggle strict memory gate ---
@@ -2209,13 +2212,13 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	// --- /pack command: list and switch packs ---
-	pi.registerCommand("pack", {
-		description: "List or switch memory packs. Usage: /pack [name]",
-		handler: async (args, ctx) => {
+	// --- /memctx-pack command: list and switch packs ---
+	const packCommand = {
+		description: "List or switch memory packs. Usage: /memctx-pack [name]",
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			const packsDir = _packsDir || resolvePacksDir(ctx.cwd);
 			if (!packsDir) {
-				ctx.ui.notify("memctx: No packs found. Use /pack-generate to create one.", "error");
+				ctx.ui.notify("memctx: No packs found. Use /memctx-pack-generate to create one.", "error");
 				return;
 			}
 
@@ -2249,7 +2252,7 @@ export default function (pi: ExtensionAPI) {
 				activePack = packName;
 				activePackPath = path.join(packsDir, packName);
 				qmdCollection = `memctx-${packName}`;
-				lastPackSwitch = { from, to: packName, reason: "manual /pack selection", confidence: "high", timestamp: nowTimestamp() };
+				lastPackSwitch = { from, to: packName, reason: "manual /memctx-pack selection", confidence: "high", timestamp: nowTimestamp() };
 
 				if (qmdAvailable) {
 					qmdEmbed(qmdCollection, activePackPath).catch(() => {});
@@ -2275,7 +2278,7 @@ export default function (pi: ExtensionAPI) {
 			activePack = target;
 			activePackPath = path.join(packsDir, target);
 			qmdCollection = `memctx-${target}`;
-			lastPackSwitch = { from, to: target, reason: "manual /pack argument", confidence: "high", timestamp: nowTimestamp() };
+			lastPackSwitch = { from, to: target, reason: "manual /memctx-pack argument", confidence: "high", timestamp: nowTimestamp() };
 
 			if (qmdAvailable) {
 				qmdEmbed(qmdCollection, activePackPath).catch(() => {});
@@ -2284,12 +2287,17 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "info");
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},
+	};
+	pi.registerCommand("memctx-pack", packCommand);
+	pi.registerCommand("pack", {
+		...packCommand,
+		description: "Deprecated alias for /memctx-pack.",
 	});
 
-	// --- /pack-generate command: generate a pack from a directory ---
-	pi.registerCommand("pack-generate", {
-		description: "Generate a memory pack from a directory of repos. Usage: /pack-generate [path] [slug]",
-		handler: async (args, ctx) => {
+	// --- /memctx-pack-generate command: generate a pack from a directory ---
+	const packGenerateCommand = {
+		description: "Generate a memory pack from a directory of repos. Usage: /memctx-pack-generate [path] [slug]",
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			// Resolve packs directory — create default if none exists
 			let packsDir = _packsDir;
 			if (!packsDir) {
@@ -2363,6 +2371,11 @@ export default function (pi: ExtensionAPI) {
 			lastPackSwitch = { from: "", to: slug, reason: "generated new pack", confidence: "high", timestamp: nowTimestamp() };
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},
+	};
+	pi.registerCommand("memctx-pack-generate", packGenerateCommand);
+	pi.registerCommand("pack-generate", {
+		...packGenerateCommand,
+		description: "Deprecated alias for /memctx-pack-generate.",
 	});
 
 	// --- memctx_search tool ---
@@ -2420,7 +2433,7 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				const hint = crossResults.length > 0
-					? "\n\nTry switching pack: " + crossResults.map((p) => "/pack " + p).join(", ")
+					? "\n\nTry switching pack: " + crossResults.map((p) => "/memctx-pack " + p).join(", ")
 					: "";
 
 				return {

--- a/test/e2e.ts
+++ b/test/e2e.ts
@@ -108,8 +108,10 @@ async function main() {
 
 	assert(!!tools.memctx_search, "memctx_search tool registered");
 	assert(!!tools.memctx_save, "memctx_save tool registered");
-	assert(!!commands.pack, "/pack command registered");
-	assert(!!commands["pack-generate"], "/pack-generate command registered");
+	assert(!!commands["memctx-pack"], "/memctx-pack command registered");
+	assert(!!commands.pack, "/pack deprecated alias registered");
+	assert(!!commands["memctx-pack-generate"], "/memctx-pack-generate command registered");
+	assert(!!commands["pack-generate"], "/pack-generate deprecated alias registered");
 	assert(!!hooks.session_start, "session_start hook registered");
 	assert(!!hooks.before_agent_start, "before_agent_start hook registered");
 	assert(!!hooks.session_before_compact, "session_before_compact hook registered");

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -813,22 +813,29 @@ describe("extension registration", () => {
 		expect(hooks["session_shutdown"]).toBeDefined();
 	});
 
-	test("registers /pack command", () => {
+	test("registers /memctx-pack command and deprecated /pack alias", () => {
 		const { pi, commands } = createMockPi();
 		registerExtension(pi as any);
 
+		expect(commands["memctx-pack"]).toBeDefined();
+		expect(commands["memctx-pack"].description).toContain("switch");
 		expect(commands["pack"]).toBeDefined();
-		expect(commands["pack"].description).toContain("switch");
+		expect(commands["pack"].description).toContain("Deprecated alias");
 	});
 
-	test("registers /pack-status and /memctx-strict commands", () => {
+	test("registers /memctx-pack-status and /memctx-strict commands", () => {
 		const { pi, commands } = createMockPi();
 		registerExtension(pi as any);
 
+		expect(commands["memctx-pack-status"]).toBeDefined();
+		expect(commands["memctx-pack-status"].description).toContain("status");
 		expect(commands["pack-status"]).toBeDefined();
-		expect(commands["pack-status"].description).toContain("status");
+		expect(commands["pack-status"].description).toContain("Deprecated alias");
 		expect(commands["memctx-strict"]).toBeDefined();
 		expect(commands["memctx-strict"].description).toContain("strict");
+		expect(commands["memctx-pack-generate"]).toBeDefined();
+		expect(commands["pack-generate"]).toBeDefined();
+		expect(commands["pack-generate"].description).toContain("Deprecated alias");
 	});
 });
 


### PR DESCRIPTION
## Summary
- add current memctx-strict and memctx-llm values to the footer/status overlay
- standardize pack commands under the memctx prefix:
  - /memctx-pack
  - /memctx-pack-status
  - /memctx-pack-generate
- keep deprecated aliases for compatibility:
  - /pack
  - /pack-status
  - /pack-generate
- update docs and tests for the new command names

## Tests
- npm run ci