### PR TITLE
fix: default strict mode on and refresh overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Footer/status overlay now includes retrieval policy and autosave mode in addition to pack, qmd/retrieval, strict mode, and LLM mode.
+- Strict mode now defaults to on for new installs and updates the footer/status overlay immediately when toggled.
 - Automatic retrieval can now attempt multiple generated queries depending on retrieval policy.
 - Context pack ordering now prioritizes overview and architecture notes before recency-only context.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ These slash commands are available inside Pi after the extension loads.
 |---|---|---|
 | `/memctx-pack` | `/memctx-pack` or `/memctx-pack <name>` | List packs with a picker or switch directly. |
 | `/memctx-pack-status` | `/memctx-pack-status` | Show active pack, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
-| `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. In strict mode, project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
+| `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. Defaults to `on`; project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
 | `/memctx-auto-switch` | `/memctx-auto-switch off\|cwd\|prompt\|all\|status` | Configure cwd/prompt-based automatic pack switching. |
 | `/memctx-llm` | `/memctx-llm off\|assist\|first\|status` | Configure LLM assistance for prompt pack switching, retrieval expansion, autosave candidates, and pack generation. |
 | `/memctx-retrieval` | `/memctx-retrieval auto\|fast\|balanced\|deep\|strict\|status` | Configure automatic retrieval depth. `auto` is the default. |
@@ -293,10 +293,10 @@ Selection: high (112)
 Last switch: none
 qmd: available
 qmd source: local-dependency
-Strict mode: off
+Strict mode: on
 LLM mode: assist
 LLM calls: 0
-Overlay: 📦 opensource · qmd:3 · retrieval:auto · save:suggest · strict:off · llm:assist
+Overlay: 📦 opensource · qmd:3 · retrieval:auto · save:suggest · strict:on · llm:assist
 Last retrieval: qmd
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,6 @@ memctx-pack-generate
 - Bounded context: lower-priority sections are trimmed before flooding the prompt.
 - qmd optional: semantic search is attempted automatically when available, but grep fallback remains the hard guarantee.
 - Observable memory state: `/memctx-pack-status` reports active pack, qmd resolution, LLM mode, strict mode, retrieval policy, autosave mode, and last retrieval; the footer overlay includes current `memctx-strict`, `memctx-llm`, retrieval, and autosave values.
-- Strict guidance is opt-in via `MEMCTX_STRICT=true` or `/memctx-strict on`.
+- Strict guidance defaults to on. Disable with `MEMCTX_STRICT=false` or `/memctx-strict off` when lower retrieval pressure is preferred.
 - Source of truth wins: repository files and live system state override memory notes.
 - Generated memory is conservative: deterministic pack generation avoids destructive commands and redacts sensitive-looking values.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,10 +53,11 @@ See `examples/basic-pack/` for a minimal public-safe pack.
 
 Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, and `/pack-generate`.
 
-Use strict mode when you want stronger retrieval guidance before project-specific answers:
+Strict mode is on by default for stronger retrieval guidance before project-specific answers. You can toggle it when needed:
 
 ```txt
 /memctx-strict on
+/memctx-strict off
 ```
 
 Configure automatic pack switching and LLM assistance:

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,7 @@ let activePackPath = "";
 let qmdAvailable = false;
 let qmdBin = "";
 let qmdCollection = "";
-let strictMode = parseBooleanEnv(process.env.MEMCTX_STRICT);
+let strictMode = parseStrictModeEnv(process.env.MEMCTX_STRICT);
 
 type SearchMode = "keyword" | "semantic" | "deep";
 type QmdSource = "env" | "path" | "local-dependency" | "missing";
@@ -154,8 +154,10 @@ let llmStats: LlmStats = {
 	estimatedOutputChars: 0,
 };
 
-function parseBooleanEnv(value: string | undefined): boolean {
-	return ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
+function parseStrictModeEnv(value: string | undefined): boolean {
+	const normalized = (value ?? "on").toLowerCase();
+	if (["0", "false", "no", "off"].includes(normalized)) return false;
+	return true;
 }
 
 function parseAutoSwitchMode(value: string | undefined): AutoSwitchMode {
@@ -2076,7 +2078,7 @@ export function _resetState() {
 	qmdBin = "";
 	qmdStatus = { available: false, source: "missing" };
 	qmdCollection = "";
-	strictMode = parseBooleanEnv(process.env.MEMCTX_STRICT);
+	strictMode = parseStrictModeEnv(process.env.MEMCTX_STRICT);
 	autoSwitchMode = parseAutoSwitchMode(process.env.MEMCTX_AUTO_SWITCH);
 	llmMode = parseLlmMode(process.env.MEMCTX_LLM_MODE);
 	retrievalPolicy = parseRetrievalPolicy(process.env.MEMCTX_RETRIEVAL);
@@ -2358,6 +2360,7 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			ctx.ui.notify(`memctx: Strict mode ${strictMode ? "on" : "off"}.`, "info");
+			ctx.ui.setStatus("memctx", buildStatusText());
 		},
 	});
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -842,6 +842,19 @@ describe("extension registration", () => {
 		expect(commands["memctx-doctor"]).toBeDefined();
 		expect(commands["memctx-pack-enrich"]).toBeDefined();
 	});
+
+	test("/memctx-strict updates the status overlay", async () => {
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		const ctx = createMockCtx();
+
+		await commands["memctx-strict"].handler("off", ctx);
+		expect(ctx.ui.setStatus).toHaveBeenCalled();
+		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("strict:off");
+
+		await commands["memctx-strict"].handler("on", ctx);
+		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("strict:on");
+	});
 });
 
 // ==========================================================================


### PR DESCRIPTION
## Summary
- default memctx strict mode to on for new installs/sessions unless MEMCTX_STRICT is explicitly false/off/0/no
- refresh the footer/status overlay immediately when /memctx-strict toggles
- document strict default-on behavior
- add regression test for strict overlay updates

## Tests
- npm run ci