### PR TITLE
fix: make auto retrieval bounded and suppress false hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Footer/status overlay now includes retrieval policy and autosave mode in addition to pack, qmd/retrieval, strict mode, and LLM mode.
 - Strict mode now defaults to on for new installs and updates the footer/status overlay immediately when toggled.
 - Automatic retrieval can now attempt multiple generated queries depending on retrieval policy.
+- `retrieval:auto` is now latency-bounded with a default 1000ms budget and no longer escalates to full strict retrieval just because strict mode is enabled.
+- `autosave:auto` now saves high-confidence candidates automatically without queue approval and does not queue low-confidence candidates unless explicitly configured.
 - Context pack ordering now prioritizes overview and architecture notes before recency-only context.
 
 ### Fixed
 
+- Suppressed false tool-failure memory hints when qmd reports `No results found`.
 - Consolidated recent LLM, qmd, GitHub Packages, and memctx-command features into the next minor release line.
 
 ## [0.3.0] - 2026-04-30

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ These slash commands are available inside Pi after the extension loads.
 | `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. Defaults to `on`; project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
 | `/memctx-auto-switch` | `/memctx-auto-switch off\|cwd\|prompt\|all\|status` | Configure cwd/prompt-based automatic pack switching. |
 | `/memctx-llm` | `/memctx-llm off\|assist\|first\|status` | Configure LLM assistance for prompt pack switching, retrieval expansion, autosave candidates, and pack generation. |
-| `/memctx-retrieval` | `/memctx-retrieval auto\|fast\|balanced\|deep\|strict\|status` | Configure automatic retrieval depth. `auto` is the default. |
-| `/memctx-autosave` | `/memctx-autosave off\|suggest\|confirm\|auto\|status` | Configure memory candidate capture after meaningful turns. |
+| `/memctx-retrieval` | `/memctx-retrieval auto\|fast\|balanced\|deep\|strict\|status` | Configure automatic retrieval depth. `auto` is the default and is latency-bounded. |
+| `/memctx-autosave` | `/memctx-autosave off\|suggest\|confirm\|auto\|status` | Configure memory candidate capture. `auto` saves high-confidence candidates without queue approval by default. |
 | `/memctx-save-queue` | `/memctx-save-queue list\|approve <id>\|reject <id>\|clear` | Review queued memory candidates. |
 | `/memctx-doctor` | `/memctx-doctor` | Diagnose active pack, qmd, retrieval, autosave, placeholders, duplicate note slugs, and secret-scan warnings. |
 | `/memctx-pack-enrich` | `/memctx-pack-enrich [source-dir]` | LLM-enrich an existing active pack from source evidence. |
@@ -287,7 +287,9 @@ Active pack: opensource
 Pack path: ~/.pi/agent/memory-vault/packs/opensource
 Auto-switch: cwd
 Retrieval policy: auto
+Retrieval budget: 1000ms
 Autosave: suggest
+Autosave low-confidence queue: off
 Save queue: 0 pending
 Selection: high (112)
 Last switch: none
@@ -331,10 +333,12 @@ For more aggressive memory behavior:
 
 ```txt
 /memctx-retrieval strict      # more retrieval attempts before each turn
-/memctx-autosave suggest     # queue memory candidates after meaningful work
-/memctx-save-queue           # review pending candidates
+/memctx-autosave auto        # save high-confidence candidates automatically
+/memctx-save-queue           # review pending candidates, if any
 /memctx-doctor               # diagnose pack/runtime health
 ```
+
+`retrieval:auto` does not imply full strict retrieval; it performs bounded retrieval with a default 1000ms latency budget. Use `/memctx-retrieval strict` when you explicitly prefer depth over latency.
 
 Switch mid-session with `/memctx-pack`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ session_start
 before_agent_start
   -> optionally switch packs from prompt intent
   -> apply retrieval policy (auto/fast/balanced/deep/strict)
+  -> keep auto retrieval latency-bounded (default 1000ms)
   -> optionally expand queries with LLM
   -> search active pack for prompt-relevant context with qmd when available
   -> fall back to grep-style Markdown search when qmd is unavailable or returns no result

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,14 +73,16 @@ Environment equivalents:
 MEMCTX_AUTO_SWITCH=off|cwd|prompt|all
 MEMCTX_LLM_MODE=off|assist|first
 MEMCTX_RETRIEVAL=auto|fast|balanced|deep|strict
+MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS=1000
 MEMCTX_AUTOSAVE=off|suggest|confirm|auto
+MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE=false
 ```
 
 Use stronger retrieval and memory capture when desired:
 
 ```txt
 /memctx-retrieval strict
-/memctx-autosave suggest
+/memctx-autosave auto
 /memctx-save-queue
 /memctx-doctor
 ```

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -26,7 +26,7 @@
 /memctx-save-queue list|approve <id>|reject <id>|clear
 ```
 
-`autosave=suggest` queues candidates and shows a widget. `autosave=auto` only writes directly when confidence is high; otherwise candidates remain reviewable.
+`autosave=suggest` queues candidates and shows a widget. `autosave=confirm` asks immediately. `autosave=auto` writes directly when confidence is high and discards low-confidence candidates by default, so it does not require queue approval. Set `MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE=true` to queue low-confidence auto candidates for review.
 
 ## Limitations
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -14,11 +14,13 @@
 /memctx-retrieval auto|fast|balanced|deep|strict|status
 ```
 
-- `auto`: default; chooses a safe policy from strict/LLM/qmd state.
+- `auto`: default; starts with fast keyword retrieval and only attempts bounded expansion when needed.
 - `fast`: one keyword query.
 - `balanced`: keyword plus LLM-expanded queries when available.
 - `deep`: multi-query retrieval with deeper qmd mode.
 - `strict`: always attempts expanded retrieval and reports attempted queries/cross-pack hints.
+
+`auto` uses `MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS` with a default of `1000`, so strict mode no longer turns `auto` into full strict retrieval. Use `/memctx-retrieval strict` when depth matters more than latency.
 
 qmd is resolved from `MEMCTX_QMD_BIN`, `PATH`, or the optional bundled `@tobilu/qmd` dependency. Without qmd, pi-memctx falls back to local grep-style Markdown search.
 

--- a/index.ts
+++ b/index.ts
@@ -124,6 +124,9 @@ type RetrievalStatus = {
 	policy: RetrievalPolicy;
 	resultCount: number;
 	crossPackHits: string[];
+	durationMs: number;
+	budgetMs: number;
+	timedOut: boolean;
 	timestamp: string;
 };
 
@@ -145,6 +148,8 @@ let autoSwitchMode: AutoSwitchMode = parseAutoSwitchMode(process.env.MEMCTX_AUTO
 let llmMode: LlmMode = parseLlmMode(process.env.MEMCTX_LLM_MODE);
 let retrievalPolicy: RetrievalPolicy = parseRetrievalPolicy(process.env.MEMCTX_RETRIEVAL);
 let autosaveMode: AutosaveMode = parseAutosaveMode(process.env.MEMCTX_AUTOSAVE);
+let retrievalLatencyBudgetMs = parsePositiveIntEnv(process.env.MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS, 1000);
+let autosaveQueueLowConfidence = parseBooleanDefaultFalse(process.env.MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE);
 let lastPackSelection: PackMatch | null = null;
 let lastPackSwitch: PackSwitch | null = null;
 let llmStats: LlmStats = {
@@ -158,6 +163,15 @@ function parseStrictModeEnv(value: string | undefined): boolean {
 	const normalized = (value ?? "on").toLowerCase();
 	if (["0", "false", "no", "off"].includes(normalized)) return false;
 	return true;
+}
+
+function parseBooleanDefaultFalse(value: string | undefined): boolean {
+	return ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
+}
+
+function parsePositiveIntEnv(value: string | undefined, fallback: number): number {
+	const parsed = Number.parseInt(value ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function parseAutoSwitchMode(value: string | undefined): AutoSwitchMode {
@@ -461,7 +475,8 @@ export async function qmdSearch(
 				? ["vsearch", query, "-n", String(limit), "-c", collection]
 				: ["search", query, "-n", String(limit), "-c", collection];
 	const result = await qmdExec(args, mode === "deep" ? 15000 : 5000);
-	return result.ok ? result.stdout : "";
+	if (!result.ok || isNoResultText(result.stdout)) return "";
+	return result.stdout;
 }
 
 export async function qmdEmbed(collection: string, packPath: string): Promise<boolean> {
@@ -619,8 +634,19 @@ async function maybeSwitchPackByPrompt(prompt: string, packsDir: string, ctx: Ex
 }
 
 function buildStatusText(): string {
-	const retrieval = lastRetrieval ? `${lastRetrieval.mode}:${lastRetrieval.resultCount}` : "idle";
+	const retrieval = lastRetrieval ? `${lastRetrieval.mode}:${lastRetrieval.resultCount}${lastRetrieval.timedOut ? ":timeout" : ""}` : "idle";
 	return `📦 ${activePack || "none"} · ${retrieval} · retrieval:${retrievalPolicy} · save:${autosaveMode} · strict:${strictMode ? "on" : "off"} · llm:${llmMode}${llmStats.callsThisSession ? `(${llmStats.callsThisSession})` : ""}`;
+}
+
+function isNoResultText(text: string): boolean {
+	const normalized = text.trim().toLowerCase().replace(/[.!]+$/, "");
+	return normalized === "no results found" || normalized === "no results";
+}
+
+function countQmdResults(text: string): number {
+	if (!text.trim() || isNoResultText(text)) return 0;
+	const uriMatches = text.match(/^qmd:\/\//gm)?.length ?? 0;
+	return uriMatches > 0 ? uriMatches : text.split("\n").filter((line) => line.trim() && !isNoResultText(line)).length;
 }
 
 export async function searchPackMemory(
@@ -634,8 +660,9 @@ export async function searchPackMemory(
 		if (!qmdResults.trim() && mode !== "keyword") {
 			qmdResults = await qmdSearch(query, qmdCollection, limit, "keyword");
 		}
-		if (qmdResults.trim()) {
-			return { text: qmdResults, mode: "qmd", matchCount: qmdResults.split("\n").filter((line) => line.trim()).length };
+		const qmdCount = countQmdResults(qmdResults);
+		if (qmdCount > 0) {
+			return { text: qmdResults, mode: "qmd", matchCount: qmdCount };
 		}
 	}
 
@@ -649,10 +676,20 @@ export async function searchPackMemory(
 
 type QueryExpansion = { queries?: string[] };
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<{ value: T; timedOut: boolean }> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<T>((resolve) => {
+		timer = setTimeout(() => resolve(fallback), timeoutMs);
+	});
+	const value = await Promise.race([promise, timeout]);
+	if (timer) clearTimeout(timer);
+	return { value, timedOut: value === fallback };
+}
+
 async function buildRetrievalQueries(prompt: string, ctx: ExtensionContext, policy: RetrievalPolicy): Promise<string[]> {
 	const sanitized = prompt.replace(/[^\w\s.,?!/-]/g, "").slice(0, 300).trim();
 	if (!sanitized) return [];
-	const effective = policy === "auto" ? (strictMode ? "strict" : llmMode === "off" ? "fast" : "balanced") : policy;
+	const effective = policy === "auto" ? "balanced" : policy;
 	if (effective === "fast") return [sanitized];
 	if (llmMode === "off" || !ctx.model) return [sanitized];
 	const decision = await completeJsonWithLlm<QueryExpansion>(ctx, "retrieval-query-expansion", [
@@ -686,23 +723,50 @@ function crossPackHitsForQuery(query: string, limit = 5): string[] {
 	return hits;
 }
 
-async function retrieveForPrompt(prompt: string, ctx: ExtensionContext): Promise<{ text: string; mode: RetrievalStatus["mode"]; count: number; query: string; queries: string[]; crossPackHits: string[] }> {
-	const queries = await buildRetrievalQueries(prompt, ctx, retrievalPolicy);
-	const effective = retrievalPolicy === "auto" ? (strictMode ? "strict" : llmMode === "off" ? "fast" : "balanced") : retrievalPolicy;
-	const mode: SearchMode = effective === "deep" || effective === "strict" ? "deep" : "keyword";
+async function retrieveForPrompt(prompt: string, ctx: ExtensionContext): Promise<{ text: string; mode: RetrievalStatus["mode"]; count: number; query: string; queries: string[]; crossPackHits: string[]; durationMs: number; budgetMs: number; timedOut: boolean }> {
+	const start = Date.now();
+	const sanitized = prompt.replace(/[^\w\s.,?!/-]/g, "").slice(0, 300).trim();
+	if (!sanitized) return { text: "", mode: "none", count: 0, query: "", queries: [], crossPackHits: [], durationMs: 0, budgetMs: retrievalLatencyBudgetMs, timedOut: false };
+
 	const parts: string[] = [];
 	let finalMode: RetrievalStatus["mode"] = "none";
 	let count = 0;
-	for (const query of queries) {
-		const result = await searchPackMemory(activePackPath, query, effective === "fast" ? 3 : 5, mode);
-		if (result.matchCount > 0) {
-			parts.push(`### Query: ${query}\n${result.text}`);
-			finalMode = result.mode;
-			count += result.matchCount;
+	let queries = [sanitized];
+	let timedOut = false;
+
+	const first = await searchPackMemory(activePackPath, sanitized, 3, "keyword");
+	if (first.matchCount > 0) {
+		parts.push(`### Query: ${sanitized}\n${first.text}`);
+		finalMode = first.mode;
+		count += first.matchCount;
+	}
+
+	if (count === 0 && retrievalPolicy !== "fast") {
+		const remainingBudget = Math.max(1, retrievalLatencyBudgetMs - (Date.now() - start));
+		const shouldExpand = retrievalPolicy !== "auto" || (llmMode !== "off" && !!ctx.model);
+		if (shouldExpand && remainingBudget > 50) {
+			const expanded = await withTimeout(buildRetrievalQueries(prompt, ctx, retrievalPolicy), remainingBudget, [sanitized]);
+			timedOut = expanded.timedOut;
+			queries = expanded.value;
+		}
+		const effective = retrievalPolicy === "auto" ? "balanced" : retrievalPolicy;
+		const mode: SearchMode = effective === "deep" || effective === "strict" ? "deep" : "keyword";
+		for (const query of queries.filter((q) => q !== sanitized)) {
+			if (retrievalPolicy === "auto" && Date.now() - start > retrievalLatencyBudgetMs) {
+				timedOut = true;
+				break;
+			}
+			const result = await searchPackMemory(activePackPath, query, 5, mode);
+			if (result.matchCount > 0) {
+				parts.push(`### Query: ${query}\n${result.text}`);
+				finalMode = result.mode;
+				count += result.matchCount;
+			}
 		}
 	}
-	const crossPackHits = count === 0 && queries[0] ? crossPackHitsForQuery(queries[0]) : [];
-	return { text: parts.join("\n\n"), mode: finalMode, count, query: queries[0] ?? "", queries, crossPackHits };
+
+	const crossPackHits = count === 0 && sanitized ? crossPackHitsForQuery(sanitized) : [];
+	return { text: parts.join("\n\n"), mode: finalMode, count, query: queries[0] ?? "", queries, crossPackHits, durationMs: Date.now() - start, budgetMs: retrievalLatencyBudgetMs, timedOut };
 }
 
 /**
@@ -2083,6 +2147,8 @@ export function _resetState() {
 	llmMode = parseLlmMode(process.env.MEMCTX_LLM_MODE);
 	retrievalPolicy = parseRetrievalPolicy(process.env.MEMCTX_RETRIEVAL);
 	autosaveMode = parseAutosaveMode(process.env.MEMCTX_AUTOSAVE);
+	retrievalLatencyBudgetMs = parsePositiveIntEnv(process.env.MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS, 1000);
+	autosaveQueueLowConfidence = parseBooleanDefaultFalse(process.env.MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE);
 	lastRetrieval = null;
 	lastPackSelection = null;
 	lastPackSwitch = null;
@@ -2157,6 +2223,9 @@ export default function (pi: ExtensionAPI) {
 		let retrievalQuery = "";
 		let retrievalQueries: string[] = [];
 		let crossPackHits: string[] = [];
+		let retrievalDurationMs = 0;
+		let retrievalBudgetMs = retrievalLatencyBudgetMs;
+		let retrievalTimedOut = false;
 
 		if (event.prompt?.trim()) {
 			const retrieval = await retrieveForPrompt(event.prompt, ctx);
@@ -2166,6 +2235,9 @@ export default function (pi: ExtensionAPI) {
 			retrievalQuery = retrieval.query;
 			retrievalQueries = retrieval.queries;
 			crossPackHits = retrieval.crossPackHits;
+			retrievalDurationMs = retrieval.durationMs;
+			retrievalBudgetMs = retrieval.budgetMs;
+			retrievalTimedOut = retrieval.timedOut;
 		}
 
 		lastRetrieval = {
@@ -2176,6 +2248,9 @@ export default function (pi: ExtensionAPI) {
 			policy: retrievalPolicy,
 			resultCount,
 			crossPackHits,
+			durationMs: retrievalDurationMs,
+			budgetMs: retrievalBudgetMs,
+			timedOut: retrievalTimedOut,
 			timestamp: nowTimestamp(),
 		};
 
@@ -2298,6 +2373,7 @@ export default function (pi: ExtensionAPI) {
 					`  query: ${lastRetrieval.query || "<none>"}`,
 					`  queries: ${lastRetrieval.queries.join(" | ") || "<none>"}`,
 					`  results: ${lastRetrieval.resultCount}`,
+					`  duration: ${lastRetrieval.durationMs}ms / ${lastRetrieval.budgetMs}ms${lastRetrieval.timedOut ? " (budget reached)" : ""}`,
 					`  cross-pack hits: ${lastRetrieval.crossPackHits.join(", ") || "<none>"}`,
 					`  at: ${lastRetrieval.timestamp}`,
 				]
@@ -2318,7 +2394,9 @@ export default function (pi: ExtensionAPI) {
 				`Pack files: ${packFileCount} markdown files`,
 				`Auto-switch: ${autoSwitchMode}`,
 				`Retrieval policy: ${retrievalPolicy}`,
+				`Retrieval budget: ${retrievalLatencyBudgetMs}ms`,
 				`Autosave: ${autosaveMode}`,
+				`Autosave low-confidence queue: ${autosaveQueueLowConfidence ? "on" : "off"}`,
 				`Save queue: ${readSaveQueue().length} pending`,
 				...selection,
 				...switchLines,
@@ -2905,7 +2983,7 @@ export default function (pi: ExtensionAPI) {
 		const text = JSON.stringify((event as any).content ?? "").slice(0, 500);
 		if (!text.trim()) return;
 		const result = await searchPackMemory(activePackPath, text, 2, "keyword");
-		if (result.matchCount > 0 && ctx.hasUI) {
+		if (result.matchCount > 0 && !isNoResultText(result.text) && ctx.hasUI) {
 			ctx.ui.setWidget("memctx-tool-failure", [
 				"\x1b[33m💡 memctx: Found memory that may help with the failed tool call.\x1b[0m",
 				truncate(result.text.replace(/\n+/g, " "), 300),
@@ -2976,13 +3054,18 @@ export default function (pi: ExtensionAPI) {
 		}
 		if (!candidate || sensitivePatternHit(candidate.title, candidate.content)) return;
 
-		if (autosaveMode === "auto" && candidate.confidence >= 0.85) {
-			try {
-				const saved = saveMemoryCandidate(candidate);
-				if (qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
-				if (ctx.hasUI) ctx.ui.notify(`memctx: Autosaved ${candidate.type}: ${saved.rel}`, "info");
-			} catch {
+		if (autosaveMode === "auto") {
+			if (candidate.confidence >= 0.85) {
+				try {
+					const saved = saveMemoryCandidate(candidate);
+					if (qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
+					if (ctx.hasUI) ctx.ui.notify(`memctx: Autosaved ${candidate.type}: ${saved.rel}`, "info");
+				} catch {
+					enqueueMemoryCandidate(candidate);
+				}
+			} else if (autosaveQueueLowConfidence) {
 				enqueueMemoryCandidate(candidate);
+				if (ctx.hasUI) ctx.ui.notify(`memctx: Queued low-confidence autosave candidate: ${candidate.title}`, "info");
 			}
 			return;
 		}


### PR DESCRIPTION
## Summary
- keep /memctx-retrieval auto latency-bounded with a default 1000ms budget
- stop treating strict mode as full strict retrieval when retrieval policy is auto
- avoid LLM query expansion before the first fast keyword attempt in auto mode
- make autosave=auto save high-confidence candidates without queue approval and discard low-confidence candidates by default
- add MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE to opt into queueing low-confidence auto candidates
- suppress false tool-failure memory hints when qmd returns 'No results found'
- expose retrieval duration/budget and autosave low-confidence queue status in /memctx-pack-status
- update README/docs/changelog

## Tests
- npm run ci
- npm pack --dry-run --json