### PR TITLE
feat: add memctx profiles and ask-first bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added `/memctx-profile auto|low|balanced|full|status` and persistent config in `~/.config/pi-memctx/config.json`; default profile is `auto`.
+- Added `/memctx-config status|reset` for inspecting/resetting persistent config.
 - Added configurable retrieval policy via `/memctx-retrieval` and `MEMCTX_RETRIEVAL=auto|fast|balanced|deep|strict`; default is `auto`.
 - Added LLM-assisted query expansion for balanced/deep/strict retrieval policies.
 - Added autosave memory candidates via `/memctx-autosave` and `MEMCTX_AUTOSAVE=off|suggest|confirm|auto`.
 - Added save candidate review queue via `/memctx-save-queue`.
 - Added `/memctx-doctor` for runtime and pack health diagnostics.
 - Added `/memctx-pack-enrich` for LLM-assisted enrichment of existing packs.
+- Added ask-first auto-bootstrap flow for creating a pack when no pack is found in a project directory.
 - Added LLM-structured session handoffs during compaction when LLM mode is enabled.
 - Added memory lookup hints after failed tool results.
 
 ### Changed
 
-- Footer/status overlay now includes retrieval policy and autosave mode in addition to pack, qmd/retrieval, strict mode, and LLM mode.
+- Footer/status overlay now includes profile, retrieval policy, and autosave mode in addition to pack, qmd/retrieval, strict mode, and LLM mode.
 - Strict mode now defaults to on for new installs and updates the footer/status overlay immediately when toggled.
 - Automatic retrieval can now attempt multiple generated queries depending on retrieval policy.
 - `retrieval:auto` is now latency-bounded with a default 1000ms budget and no longer escalates to full strict retrieval just because strict mode is enabled.

--- a/README.md
+++ b/README.md
@@ -266,8 +266,10 @@ These slash commands are available inside Pi after the extension loads.
 
 | Command | Usage | What |
 |---|---|---|
+| `/memctx-profile` | `/memctx-profile auto\|low\|balanced\|full\|status` | Apply a zero-config behavior profile. Default is `auto`. |
+| `/memctx-config` | `/memctx-config status\|reset` | Inspect or reset persistent config in `~/.config/pi-memctx/config.json`. |
 | `/memctx-pack` | `/memctx-pack` or `/memctx-pack <name>` | List packs with a picker or switch directly. |
-| `/memctx-pack-status` | `/memctx-pack-status` | Show active pack, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
+| `/memctx-pack-status` | `/memctx-pack-status` | Show active pack, profile/config, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
 | `/memctx-strict` | `/memctx-strict on\|off\|status` | Toggle stronger Memory Gate guidance. Defaults to `on`; project-specific answers should call `memctx_search` unless injected memory fully supports the answer. |
 | `/memctx-auto-switch` | `/memctx-auto-switch off\|cwd\|prompt\|all\|status` | Configure cwd/prompt-based automatic pack switching. |
 | `/memctx-llm` | `/memctx-llm off\|assist\|first\|status` | Configure LLM assistance for prompt pack switching, retrieval expansion, autosave candidates, and pack generation. |
@@ -283,6 +285,8 @@ Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, 
 ### `/memctx-pack-status` example
 
 ```txt
+Profile: auto
+Config path: ~/.config/pi-memctx/config.json
 Active pack: opensource
 Pack path: ~/.pi/agent/memory-vault/packs/opensource
 Auto-switch: cwd
@@ -298,7 +302,7 @@ qmd source: local-dependency
 Strict mode: on
 LLM mode: assist
 LLM calls: 0
-Overlay: 📦 opensource · qmd:3 · retrieval:auto · save:suggest · strict:on · llm:assist
+Overlay: 📦 opensource · profile:auto · qmd:3 · retrieval:auto · save:auto · strict:on · llm:assist
 Last retrieval: qmd
 ```
 
@@ -318,6 +322,14 @@ With multiple packs, pi-memctx auto-detects the best one based on your working d
 cd ~/code/my-api       # → loads "my-api" pack
 cd ~/code/my-infra     # → loads "infra" pack
 cd ~/code              # → loads org-level pack
+```
+
+For most users, no setup is needed: `profile:auto` is applied by default. Switch profile when you want different trade-offs:
+
+```txt
+/memctx-profile low       # low latency/cost
+/memctx-profile balanced  # review memory candidates
+/memctx-profile full      # maximum retrieval/LLM usage
 ```
 
 Switch mid-session with `/memctx-pack`, or enable prompt-based switching:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,9 @@ pi-memctx is a single Pi extension implemented in `index.ts`.
 
 ```txt
 session_start
+  -> load persistent profile/config from ~/.config/pi-memctx/config.json
   -> resolve pack directory
+  -> ask before bootstrapping a pack when no pack is found
   -> detect active pack
   -> resolve qmd from MEMCTX_QMD_BIN, PATH, or bundled optional dependency
   -> optionally index with qmd
@@ -51,7 +53,7 @@ memctx-pack-generate
 - Markdown-first: memory is reviewable with normal tools.
 - Bounded context: lower-priority sections are trimmed before flooding the prompt.
 - qmd optional: semantic search is attempted automatically when available, but grep fallback remains the hard guarantee.
-- Observable memory state: `/memctx-pack-status` reports active pack, qmd resolution, LLM mode, strict mode, retrieval policy, autosave mode, and last retrieval; the footer overlay includes current `memctx-strict`, `memctx-llm`, retrieval, and autosave values.
+- Observable memory state: `/memctx-pack-status` reports active pack, profile/config, qmd resolution, LLM mode, strict mode, retrieval policy, autosave mode, and last retrieval; the footer overlay includes current profile, `memctx-strict`, `memctx-llm`, retrieval, and autosave values.
 - Strict guidance defaults to on. Disable with `MEMCTX_STRICT=false` or `/memctx-strict off` when lower retrieval pressure is preferred.
 - Source of truth wins: repository files and live system state override memory notes.
 - Generated memory is conservative: deterministic pack generation avoids destructive commands and redacts sensitive-looking values.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,6 +53,8 @@ See `examples/basic-pack/` for a minimal public-safe pack.
 
 Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, and `/pack-generate`.
 
+pi-memctx starts with `profile:auto` and persists config in `~/.config/pi-memctx/config.json`. Use `/memctx-profile low|balanced|auto|full` to switch behavior profiles, or `/memctx-config reset` to return to defaults.
+
 Strict mode is on by default for stronger retrieval guidance before project-specific answers. You can toggle it when needed:
 
 ```txt
@@ -60,7 +62,7 @@ Strict mode is on by default for stronger retrieval guidance before project-spec
 /memctx-strict off
 ```
 
-Configure automatic pack switching and LLM assistance:
+Advanced commands can override the active profile and mark it `custom`:
 
 ```txt
 /memctx-auto-switch all

--- a/index.ts
+++ b/index.ts
@@ -80,6 +80,9 @@ type AutoSwitchMode = "off" | "cwd" | "prompt" | "all";
 type LlmMode = "off" | "assist" | "first";
 type RetrievalPolicy = "auto" | "fast" | "balanced" | "deep" | "strict";
 type AutosaveMode = "off" | "suggest" | "confirm" | "auto";
+type MemctxProfile = "low" | "balanced" | "auto" | "full" | "custom";
+type AutoBootstrapMode = "off" | "ask" | "on";
+type StartupDoctorMode = "off" | "light" | "full";
 type Confidence = "none" | "low" | "medium" | "high";
 
 type PackMatch = {
@@ -142,6 +145,26 @@ type MemoryCandidate = {
 	pack: string;
 };
 
+type MemctxConfig = {
+	profile: MemctxProfile;
+	baseProfile?: Exclude<MemctxProfile, "custom">;
+	strict: boolean;
+	retrieval: RetrievalPolicy;
+	retrievalLatencyBudgetMs: number;
+	autosave: AutosaveMode;
+	autosaveQueueLowConfidence: boolean;
+	llm: LlmMode;
+	autoSwitch: AutoSwitchMode;
+	autoBootstrap: AutoBootstrapMode;
+	startupDoctor: StartupDoctorMode;
+	toolFailureHints: boolean;
+};
+
+let currentProfile: MemctxProfile = "auto";
+let baseProfile: Exclude<MemctxProfile, "custom"> = "auto";
+let autoBootstrapMode: AutoBootstrapMode = "ask";
+let startupDoctorMode: StartupDoctorMode = "light";
+let toolFailureHints = true;
 let qmdStatus: QmdStatus = { available: false, source: "missing" };
 let lastRetrieval: RetrievalStatus | null = null;
 let autoSwitchMode: AutoSwitchMode = parseAutoSwitchMode(process.env.MEMCTX_AUTO_SWITCH);
@@ -192,6 +215,84 @@ function parseRetrievalPolicy(value: string | undefined): RetrievalPolicy {
 function parseAutosaveMode(value: string | undefined): AutosaveMode {
 	const normalized = (value ?? "suggest").toLowerCase();
 	return ["off", "suggest", "confirm", "auto"].includes(normalized) ? normalized as AutosaveMode : "suggest";
+}
+
+function parseAutoBootstrapMode(value: string | undefined): AutoBootstrapMode {
+	const normalized = (value ?? "ask").toLowerCase();
+	return ["off", "ask", "on"].includes(normalized) ? normalized as AutoBootstrapMode : "ask";
+}
+
+function parseStartupDoctorMode(value: string | undefined): StartupDoctorMode {
+	const normalized = (value ?? "light").toLowerCase();
+	return ["off", "light", "full"].includes(normalized) ? normalized as StartupDoctorMode : "light";
+}
+
+function memctxConfigPath(): string {
+	if (process.env.MEMCTX_CONFIG_PATH) return process.env.MEMCTX_CONFIG_PATH;
+	return path.join(process.env.HOME ?? process.env.USERPROFILE ?? ".", ".config", "pi-memctx", "config.json");
+}
+
+function profileDefaults(profile: Exclude<MemctxProfile, "custom">): MemctxConfig {
+	const base: Record<Exclude<MemctxProfile, "custom">, MemctxConfig> = {
+		low: { profile: "low", strict: false, retrieval: "fast", retrievalLatencyBudgetMs: 300, autosave: "off", autosaveQueueLowConfidence: false, llm: "off", autoSwitch: "cwd", autoBootstrap: "ask", startupDoctor: "off", toolFailureHints: false },
+		balanced: { profile: "balanced", strict: true, retrieval: "balanced", retrievalLatencyBudgetMs: 1000, autosave: "suggest", autosaveQueueLowConfidence: false, llm: "assist", autoSwitch: "all", autoBootstrap: "ask", startupDoctor: "light", toolFailureHints: true },
+		auto: { profile: "auto", strict: true, retrieval: "auto", retrievalLatencyBudgetMs: 1000, autosave: "auto", autosaveQueueLowConfidence: false, llm: "assist", autoSwitch: "all", autoBootstrap: "ask", startupDoctor: "light", toolFailureHints: true },
+		full: { profile: "full", strict: true, retrieval: "strict", retrievalLatencyBudgetMs: 3000, autosave: "auto", autosaveQueueLowConfidence: false, llm: "first", autoSwitch: "all", autoBootstrap: "ask", startupDoctor: "full", toolFailureHints: true },
+	};
+	return { ...base[profile], baseProfile: profile };
+}
+
+function readMemctxConfig(): MemctxConfig {
+	const raw = readFileSafe(memctxConfigPath());
+	const fallback = profileDefaults("auto");
+	if (!raw) return fallback;
+	try {
+		const parsed = JSON.parse(raw) as Partial<MemctxConfig>;
+		const profile = (["low", "balanced", "auto", "full", "custom"].includes(String(parsed.profile)) ? parsed.profile : "auto") as MemctxProfile;
+		const base = (profile === "custom" && ["low", "balanced", "auto", "full"].includes(String(parsed.baseProfile)) ? parsed.baseProfile : profile === "custom" ? "auto" : profile) as Exclude<MemctxProfile, "custom">;
+		return { ...profileDefaults(base), ...parsed, profile, baseProfile: base };
+	} catch {
+		return fallback;
+	}
+}
+
+function writeMemctxConfig(config: MemctxConfig) {
+	const configPath = memctxConfigPath();
+	fs.mkdirSync(path.dirname(configPath), { recursive: true });
+	fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+function envOrConfig<T>(envValue: string | undefined, parsed: T, fallback: T): T {
+	return envValue === undefined ? fallback : parsed;
+}
+
+function applyMemctxConfig(config: MemctxConfig) {
+	currentProfile = config.profile;
+	baseProfile = config.baseProfile ?? (config.profile === "custom" ? "auto" : config.profile);
+	strictMode = envOrConfig(process.env.MEMCTX_STRICT, parseStrictModeEnv(process.env.MEMCTX_STRICT), config.strict);
+	retrievalPolicy = envOrConfig(process.env.MEMCTX_RETRIEVAL, parseRetrievalPolicy(process.env.MEMCTX_RETRIEVAL), config.retrieval);
+	retrievalLatencyBudgetMs = envOrConfig(process.env.MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS, parsePositiveIntEnv(process.env.MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS, 1000), config.retrievalLatencyBudgetMs);
+	autosaveMode = envOrConfig(process.env.MEMCTX_AUTOSAVE, parseAutosaveMode(process.env.MEMCTX_AUTOSAVE), config.autosave);
+	autosaveQueueLowConfidence = envOrConfig(process.env.MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE, parseBooleanDefaultFalse(process.env.MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE), config.autosaveQueueLowConfidence);
+	llmMode = envOrConfig(process.env.MEMCTX_LLM_MODE, parseLlmMode(process.env.MEMCTX_LLM_MODE), config.llm);
+	autoSwitchMode = envOrConfig(process.env.MEMCTX_AUTO_SWITCH, parseAutoSwitchMode(process.env.MEMCTX_AUTO_SWITCH), config.autoSwitch);
+	autoBootstrapMode = envOrConfig(process.env.MEMCTX_AUTO_BOOTSTRAP, parseAutoBootstrapMode(process.env.MEMCTX_AUTO_BOOTSTRAP), config.autoBootstrap);
+	startupDoctorMode = envOrConfig(process.env.MEMCTX_STARTUP_DOCTOR, parseStartupDoctorMode(process.env.MEMCTX_STARTUP_DOCTOR), config.startupDoctor);
+	toolFailureHints = envOrConfig(process.env.MEMCTX_TOOL_FAILURE_HINTS, parseBooleanDefaultFalse(process.env.MEMCTX_TOOL_FAILURE_HINTS), config.toolFailureHints);
+	llmStats.mode = llmMode;
+}
+
+function currentMemctxConfig(profile: MemctxProfile = currentProfile): MemctxConfig {
+	return { profile, baseProfile, strict: strictMode, retrieval: retrievalPolicy, retrievalLatencyBudgetMs, autosave: autosaveMode, autosaveQueueLowConfidence, llm: llmMode, autoSwitch: autoSwitchMode, autoBootstrap: autoBootstrapMode, startupDoctor: startupDoctorMode, toolFailureHints };
+}
+
+function persistCurrentConfig(profile: MemctxProfile = currentProfile) {
+	writeMemctxConfig(currentMemctxConfig(profile));
+}
+
+function markCustomAndPersist() {
+	currentProfile = "custom";
+	persistCurrentConfig("custom");
 }
 
 function confidenceForScore(score: number): Confidence {
@@ -635,7 +736,7 @@ async function maybeSwitchPackByPrompt(prompt: string, packsDir: string, ctx: Ex
 
 function buildStatusText(): string {
 	const retrieval = lastRetrieval ? `${lastRetrieval.mode}:${lastRetrieval.resultCount}${lastRetrieval.timedOut ? ":timeout" : ""}` : "idle";
-	return `📦 ${activePack || "none"} · ${retrieval} · retrieval:${retrievalPolicy} · save:${autosaveMode} · strict:${strictMode ? "on" : "off"} · llm:${llmMode}${llmStats.callsThisSession ? `(${llmStats.callsThisSession})` : ""}`;
+	return `📦 ${activePack || "none"} · profile:${currentProfile} · ${retrieval} · retrieval:${retrievalPolicy} · save:${autosaveMode} · strict:${strictMode ? "on" : "off"} · llm:${llmMode}${llmStats.callsThisSession ? `(${llmStats.callsThisSession})` : ""}`;
 }
 
 function isNoResultText(text: string): boolean {
@@ -1150,13 +1251,29 @@ function enqueueMemoryCandidate(candidate: MemoryCandidate) {
 	if (!duplicate) writeSaveQueue([...queue, candidate]);
 }
 
+function findSimilarNote(candidate: MemoryCandidate): string | null {
+	if (!activePackPath) return null;
+	const terms = candidate.title.toLowerCase().split(/\s+/).filter((term) => term.length > 3).slice(0, 6);
+	if (terms.length === 0) return null;
+	const dirs = NOTE_TYPE_DIRS[candidate.type].map((dir) => path.join(activePackPath, dir)).filter((dir) => fs.existsSync(dir));
+	for (const dir of dirs) {
+		for (const file of scanPackFiles(dir).slice(0, 40)) {
+			const content = readFileSafe(file)?.toLowerCase() ?? "";
+			const score = terms.filter((term) => content.includes(term)).length;
+			if (score >= Math.min(3, terms.length)) return file;
+		}
+	}
+	return null;
+}
+
 function saveMemoryCandidate(candidate: MemoryCandidate): { rel: string; action: "created" | "updated" } {
 	if (!activePackPath || !activePack) throw new Error("No active memory pack");
 	if (sensitivePatternHit(candidate.title, candidate.content)) throw new Error("Candidate appears to contain secrets");
 	const noteDir = resolveNoteDir(activePackPath, candidate.type);
 	const fileSlug = slugify(candidate.title);
+	const similarPath = findSimilarNote(candidate);
 	const fileName = candidate.type === "action" ? `${todayStr()}-${fileSlug}.md` : `${fileSlug}.md`;
-	const filePath = path.join(noteDir, fileName);
+	const filePath = similarPath ?? path.join(noteDir, fileName);
 	const body = `${candidate.content}\n\n## Evidence\n\n- Confidence: ${Math.round(candidate.confidence * 100)}%\n- Reason: ${candidate.reason}`;
 	if (fs.existsSync(filePath)) {
 		const existing = readFileSafe(filePath) ?? "";
@@ -2112,6 +2229,39 @@ ${rows.join("\n")}
 	return { packPath, filesCreated };
 }
 
+function looksLikeProjectDirectory(cwd: string): boolean {
+	const basename = path.basename(cwd);
+	if (!cwd || cwd === path.parse(cwd).root) return false;
+	if (["", "~", "home", "users", "downloads", "desktop", "documents"].includes(basename.toLowerCase())) return false;
+	const signals = [".git", "package.json", "go.mod", "README.md", "pyproject.toml", "Cargo.toml", "docker-compose.yml", "pnpm-workspace.yaml"];
+	return signals.some((signal) => fs.existsSync(path.join(cwd, signal)));
+}
+
+async function maybeBootstrapPack(ctx: ExtensionContext, packsDir: string): Promise<boolean> {
+	if (autoBootstrapMode === "off" || !looksLikeProjectDirectory(ctx.cwd)) return false;
+	if (!ctx.hasUI) return false;
+	const slug = path.basename(ctx.cwd).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "project";
+	const message = [
+		`No memory pack was found for this project directory:`,
+		ctx.cwd,
+		"",
+		`Create and map a new pack named \"${slug}\" now?`,
+		"Choose No if you prefer to run /memctx-pack-generate later.",
+	].join("\n");
+	const confirmed = autoBootstrapMode === "on" ? await ctx.ui.confirm("Create memory pack?", message) : await ctx.ui.confirm("Create memory pack?", message);
+	if (!confirmed) {
+		ctx.ui.notify("memctx: Pack bootstrap skipped. Run /memctx-pack-generate when you want to create one.", "info");
+		return false;
+	}
+	fs.mkdirSync(packsDir, { recursive: true });
+	const { packPath, filesCreated } = generatePackFromDirectory(ctx.cwd, slug, packsDir);
+	activePack = slug;
+	activePackPath = packPath;
+	qmdCollection = `memctx-${slug}`;
+	ctx.ui.notify(`memctx: Created pack \"${slug}\" with ${filesCreated.length} files.`, "info");
+	return true;
+}
+
 // ---------------------------------------------------------------------------
 // Test hooks (override state for testing)
 // ---------------------------------------------------------------------------
@@ -2142,13 +2292,7 @@ export function _resetState() {
 	qmdBin = "";
 	qmdStatus = { available: false, source: "missing" };
 	qmdCollection = "";
-	strictMode = parseStrictModeEnv(process.env.MEMCTX_STRICT);
-	autoSwitchMode = parseAutoSwitchMode(process.env.MEMCTX_AUTO_SWITCH);
-	llmMode = parseLlmMode(process.env.MEMCTX_LLM_MODE);
-	retrievalPolicy = parseRetrievalPolicy(process.env.MEMCTX_RETRIEVAL);
-	autosaveMode = parseAutosaveMode(process.env.MEMCTX_AUTOSAVE);
-	retrievalLatencyBudgetMs = parsePositiveIntEnv(process.env.MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS, 1000);
-	autosaveQueueLowConfidence = parseBooleanDefaultFalse(process.env.MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE);
+	applyMemctxConfig(profileDefaults("auto"));
 	lastRetrieval = null;
 	lastPackSelection = null;
 	lastPackSwitch = null;
@@ -2163,17 +2307,22 @@ export function _resetState() {
 export default function (pi: ExtensionAPI) {
 	// --- session_start: detect vault, active pack, qmd ---
 	pi.on("session_start", async (_event, ctx) => {
-		// Resolve packs directory
-		const packsDir = resolvePacksDir(ctx.cwd);
+		applyMemctxConfig(readMemctxConfig());
+		let packsDir = resolvePacksDir(ctx.cwd);
 
 		if (!packsDir) {
-			if (ctx.hasUI) {
-				ctx.ui.notify(
-					"memctx: No packs found. Set MEMCTX_PACKS_PATH, create .pi/memory-vault/packs/, or use ~/.pi/agent/memory-vault/packs/",
-					"info",
-				);
+			const bootstrapped = await maybeBootstrapPack(ctx, DEFAULT_GLOBAL_PACKS_DIR);
+			if (bootstrapped) {
+				packsDir = DEFAULT_GLOBAL_PACKS_DIR;
+			} else {
+				if (ctx.hasUI) {
+					ctx.ui.notify(
+						"memctx: No packs found. Run /memctx-pack-generate to create one, or set MEMCTX_PACKS_PATH.",
+						"info",
+					);
+				}
+				return;
 			}
-			return;
 		}
 
 		vaultRoot = path.dirname(packsDir);
@@ -2204,7 +2353,15 @@ export default function (pi: ExtensionAPI) {
 				? `qmd ✓ (${qmdStatus.source})`
 				: "qmd ✗ (grep fallback)";
 			const selection = lastPackSelection?.pack === activePack ? ` ${lastPackSelection.confidence} cwd match` : "";
-			ctx.ui.notify(`memctx: Pack "${activePack}" loaded.${selection} ${qmdLabel}`, "info");
+			ctx.ui.notify(`memctx: Pack "${activePack}" loaded.${selection} ${qmdLabel} profile:${currentProfile}`, "info");
+			if (startupDoctorMode !== "off") {
+				const queueCount = readSaveQueue().length;
+				const warnings = [
+					!qmdAvailable ? "qmd unavailable; using grep fallback" : "",
+					queueCount > 0 ? `${queueCount} memory candidate${queueCount === 1 ? "" : "s"} pending review` : "",
+				].filter(Boolean);
+				if (warnings.length > 0) ctx.ui.notify(`memctx doctor: ${warnings.join("; ")}`, "warning");
+			}
 			ctx.ui.setStatus("memctx", buildStatusText());
 		}
 	});
@@ -2388,6 +2545,8 @@ export default function (pi: ExtensionAPI) {
 				? [`Last switch: ${lastPackSwitch.from || "<none>"} → ${lastPackSwitch.to}`, `  reason: ${lastPackSwitch.reason}`, `  at: ${lastPackSwitch.timestamp}`]
 				: ["Last switch: none"];
 			const lines = [
+				`Profile: ${currentProfile}${currentProfile === "custom" ? ` (base ${baseProfile})` : ""}`,
+				`Config path: ${memctxConfigPath()}`,
 				`Active pack: ${activePack || "<none>"}`,
 				`Pack path: ${activePackPath || "<none>"}`,
 				`Packs dir: ${packsDir || "<none>"}`,
@@ -2424,19 +2583,70 @@ export default function (pi: ExtensionAPI) {
 		description: "Deprecated alias for /memctx-pack-status.",
 	});
 
+	// --- /memctx-profile command: apply zero-config behavior profiles ---
+	pi.registerCommand("memctx-profile", {
+		description: "Apply a memory behavior profile. Usage: /memctx-profile [auto|low|balanced|full|status]",
+		handler: async (args, ctx) => {
+			const target = (args ?? "status").trim().toLowerCase();
+			if (["low", "balanced", "auto", "full"].includes(target)) {
+				const config = profileDefaults(target as Exclude<MemctxProfile, "custom">);
+				applyMemctxConfig(config);
+				writeMemctxConfig(config);
+			} else if (target && target !== "status") {
+				ctx.ui.notify("memctx: Usage: /memctx-profile [auto|low|balanced|full|status]", "error");
+				return;
+			}
+			ctx.ui.notify([
+				`memctx profile: ${currentProfile}`,
+				`strict: ${strictMode ? "on" : "off"}`,
+				`retrieval: ${retrievalPolicy} (${retrievalLatencyBudgetMs}ms)`,
+				`autosave: ${autosaveMode}`,
+				`llm: ${llmMode}`,
+				`auto-switch: ${autoSwitchMode}`,
+				`auto-bootstrap: ${autoBootstrapMode}`,
+			].join("\n"), "info");
+			ctx.ui.setStatus("memctx", buildStatusText());
+		},
+	});
+
+	// --- /memctx-config command: inspect/reset persistent config ---
+	pi.registerCommand("memctx-config", {
+		description: "Show or reset persistent memctx config. Usage: /memctx-config [status|reset]",
+		handler: async (args, ctx) => {
+			const target = (args ?? "status").trim().toLowerCase();
+			if (target === "reset") {
+				const config = profileDefaults("auto");
+				applyMemctxConfig(config);
+				writeMemctxConfig(config);
+				ctx.ui.notify("memctx: Config reset to profile:auto.", "info");
+				ctx.ui.setStatus("memctx", buildStatusText());
+				return;
+			}
+			if (target && target !== "status") {
+				ctx.ui.notify("memctx: Usage: /memctx-config [status|reset]", "error");
+				return;
+			}
+			ctx.ui.notify(`memctx config: ${memctxConfigPath()}\n${JSON.stringify(currentMemctxConfig(), null, 2)}`, "info");
+		},
+	});
+
 	// --- /memctx-strict command: toggle strict memory gate ---
 	pi.registerCommand("memctx-strict", {
 		description: "Toggle strict memory retrieval guidance. Usage: /memctx-strict [on|off|status]",
 		handler: async (args, ctx) => {
 			const target = (args ?? "status").trim().toLowerCase();
+			let changed = false;
 			if (["on", "true", "1", "yes"].includes(target)) {
 				strictMode = true;
+				changed = true;
 			} else if (["off", "false", "0", "no"].includes(target)) {
 				strictMode = false;
+				changed = true;
 			} else if (target && target !== "status") {
 				ctx.ui.notify("memctx: Usage: /memctx-strict [on|off|status]", "error");
 				return;
 			}
+			if (changed) markCustomAndPersist();
 			ctx.ui.notify(`memctx: Strict mode ${strictMode ? "on" : "off"}.`, "info");
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},
@@ -2447,12 +2657,15 @@ export default function (pi: ExtensionAPI) {
 		description: "Configure automatic pack switching. Usage: /memctx-auto-switch [off|cwd|prompt|all|status]",
 		handler: async (args, ctx) => {
 			const target = (args ?? "status").trim().toLowerCase();
+			let changed = false;
 			if (["off", "cwd", "prompt", "all"].includes(target)) {
 				autoSwitchMode = target as AutoSwitchMode;
+				changed = true;
 			} else if (target && target !== "status") {
 				ctx.ui.notify("memctx: Usage: /memctx-auto-switch [off|cwd|prompt|all|status]", "error");
 				return;
 			}
+			if (changed) markCustomAndPersist();
 			ctx.ui.notify(`memctx: Auto-switch ${autoSwitchMode}.`, "info");
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},
@@ -2463,13 +2676,16 @@ export default function (pi: ExtensionAPI) {
 		description: "Configure LLM assistance. Usage: /memctx-llm [off|assist|first|status]",
 		handler: async (args, ctx) => {
 			const target = (args ?? "status").trim().toLowerCase();
+			let changed = false;
 			if (["off", "assist", "first"].includes(target)) {
 				llmMode = target as LlmMode;
 				llmStats.mode = llmMode;
+				changed = true;
 			} else if (target && target !== "status") {
 				ctx.ui.notify("memctx: Usage: /memctx-llm [off|assist|first|status]", "error");
 				return;
 			}
+			if (changed) markCustomAndPersist();
 			ctx.ui.notify(`memctx: LLM mode ${llmMode}. Calls this session: ${llmStats.callsThisSession}. Last: ${llmStats.lastUseCase ?? "none"}.`, "info");
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},
@@ -2480,12 +2696,15 @@ export default function (pi: ExtensionAPI) {
 		description: "Configure automatic memory retrieval. Usage: /memctx-retrieval [auto|fast|balanced|deep|strict|status]",
 		handler: async (args, ctx) => {
 			const target = (args ?? "status").trim().toLowerCase();
+			let changed = false;
 			if (["auto", "fast", "balanced", "deep", "strict"].includes(target)) {
 				retrievalPolicy = target as RetrievalPolicy;
+				changed = true;
 			} else if (target && target !== "status") {
 				ctx.ui.notify("memctx: Usage: /memctx-retrieval [auto|fast|balanced|deep|strict|status]", "error");
 				return;
 			}
+			if (changed) markCustomAndPersist();
 			ctx.ui.notify(`memctx: Retrieval policy ${retrievalPolicy}.`, "info");
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},
@@ -2496,12 +2715,15 @@ export default function (pi: ExtensionAPI) {
 		description: "Configure memory save suggestions. Usage: /memctx-autosave [off|suggest|confirm|auto|status]",
 		handler: async (args, ctx) => {
 			const target = (args ?? "status").trim().toLowerCase();
+			let changed = false;
 			if (["off", "suggest", "confirm", "auto"].includes(target)) {
 				autosaveMode = target as AutosaveMode;
+				changed = true;
 			} else if (target && target !== "status") {
 				ctx.ui.notify("memctx: Usage: /memctx-autosave [off|suggest|confirm|auto|status]", "error");
 				return;
 			}
+			if (changed) markCustomAndPersist();
 			ctx.ui.notify(`memctx: Autosave ${autosaveMode}. Save queue: ${readSaveQueue().length} pending.`, "info");
 			ctx.ui.setStatus("memctx", buildStatusText());
 		},

--- a/test/e2e.ts
+++ b/test/e2e.ts
@@ -117,6 +117,8 @@ async function main() {
 	assert(!!commands["memctx-save-queue"], "/memctx-save-queue command registered");
 	assert(!!commands["memctx-doctor"], "/memctx-doctor command registered");
 	assert(!!commands["memctx-pack-enrich"], "/memctx-pack-enrich command registered");
+	assert(!!commands["memctx-profile"], "/memctx-profile command registered");
+	assert(!!commands["memctx-config"], "/memctx-config command registered");
 	assert(!!hooks.session_start, "session_start hook registered");
 	assert(!!hooks.before_agent_start, "before_agent_start hook registered");
 	assert(!!hooks.session_before_compact, "session_before_compact hook registered");

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -44,10 +44,12 @@ let tmpDir: string;
 
 function setupTmpDir() {
 	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "amv-test-"));
+	process.env.MEMCTX_CONFIG_PATH = path.join(tmpDir, "config.json");
 }
 
 function cleanupTmpDir() {
 	_resetState();
+	delete process.env.MEMCTX_CONFIG_PATH;
 	fs.rmSync(tmpDir, { recursive: true, force: true });
 }
 
@@ -259,6 +261,7 @@ function createMockCtx(sessionId = "abcdef1234567890") {
 			notify: mock(() => {}),
 			setStatus: mock(() => {}),
 			setWidget: mock(() => {}),
+			confirm: mock(async () => false),
 		},
 		cwd: tmpDir,
 	};
@@ -841,7 +844,10 @@ describe("extension registration", () => {
 		expect(commands["memctx-save-queue"]).toBeDefined();
 		expect(commands["memctx-doctor"]).toBeDefined();
 		expect(commands["memctx-pack-enrich"]).toBeDefined();
+		expect(commands["memctx-profile"]).toBeDefined();
+		expect(commands["memctx-config"]).toBeDefined();
 	});
+
 
 	test("/memctx-strict updates the status overlay", async () => {
 		const { pi, commands } = createMockPi();


### PR DESCRIPTION
## Summary
- add persistent zero-config profiles via /memctx-profile auto|low|balanced|full|status
- add /memctx-config status|reset backed by ~/.config/pi-memctx/config.json
- default new installs/sessions to profile:auto
- make advanced commands persist overrides and mark the profile as custom
- include profile/config in overlay and /memctx-pack-status
- add ask-first bootstrap prompt when no pack is found in a project directory
- add light startup doctor warnings for qmd fallback and pending save candidates
- keep auto-bootstrap user-confirmed: users can skip and run /memctx-pack-generate later
- improve autosave persistence by appending to similar notes when possible
- update README/docs/changelog and tests

## Tests
- npm run ci
- npm pack --dry-run --json