### PR TITLE
feat: automate releases from main merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,11 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches: [main]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, for example v0.3.0"
+        description: "Release tag, for example v0.4.0"
         required: true
         type: string
 
@@ -15,6 +14,11 @@ permissions:
   contents: write
   id-token: write
   packages: write
+  pull-requests: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -24,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ github.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -33,38 +38,178 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Resolve release version
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ inputs.tag }}
         shell: bash
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+            TAG="$INPUT_TAG"
+            if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release tag must look like v1.2.3. Got: $TAG" >&2
+              exit 1
+            fi
+
+            VERSION="${TAG#v}"
+            PKG_VERSION="$(node -p "require('./package.json').version")"
+            if [ "$VERSION" != "$PKG_VERSION" ]; then
+              echo "Tag version $VERSION does not match package.json version $PKG_VERSION" >&2
+              exit 1
+            fi
+
+            echo "mode=manual" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release tag must look like v1.2.3. Got: $TAG" >&2
-            exit 1
+          SHA="${GITHUB_SHA}"
+          MESSAGE="$(git log -1 --pretty=%B "$SHA")"
+          PR_NUMBER="$(printf '%s\n' "$MESSAGE" | sed -nE 's/^Merge pull request #([0-9]+).*/\1/p' | head -n1)"
+          BRANCH=""
+          PR_TITLE=""
+          PR_URL=""
+
+          if [ -n "$PR_NUMBER" ]; then
+            PR_JSON="$(gh pr view "$PR_NUMBER" --json headRefName,title,url)"
+            BRANCH="$(node -e 'const p=JSON.parse(process.argv[1]); console.log(p.headRefName || "")' "$PR_JSON")"
+            PR_TITLE="$(node -e 'const p=JSON.parse(process.argv[1]); console.log(p.title || "")' "$PR_JSON")"
+            PR_URL="$(node -e 'const p=JSON.parse(process.argv[1]); console.log(p.url || "")' "$PR_JSON")"
           fi
 
-          VERSION="${TAG#v}"
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-
-          if [ "$VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version $VERSION does not match package.json version $PKG_VERSION" >&2
-            exit 1
+          if [ -z "$BRANCH" ]; then
+            BRANCH="$(printf '%s\n' "$MESSAGE" | sed -nE 's/^Merge pull request #[0-9]+ from [^/]+\/(.+)$/\1/p' | head -n1)"
           fi
 
+          if [ -z "$BRANCH" ]; then
+            echo "No merged PR branch found in the main push; skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BRANCH_KIND="$(printf '%s' "$BRANCH" | sed -E 's#^([^/-]+).*#\1#' | tr '[:upper:]' '[:lower:]')"
+          case "$BRANCH_KIND" in
+            feat|feature)
+              BUMP="minor"
+              ;;
+            fix|bugfix|hotfix)
+              BUMP="patch"
+              ;;
+            *)
+              echo "Merged branch '$BRANCH' does not start with feat/ or fix/; skipping release."
+              echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+              echo "release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          CURRENT="$(node -p "require('./package.json').version")"
+          VERSION="$(node -e '
+            const [major, minor, patch] = process.argv[1].split(".").map(Number);
+            const bump = process.argv[2];
+            if (![major, minor, patch].every(Number.isInteger)) throw new Error(`Invalid version: ${process.argv[1]}`);
+            if (bump === "minor") console.log(`${major}.${minor + 1}.0`);
+            else if (bump === "patch") console.log(`${major}.${minor}.${patch + 1}`);
+            else throw new Error(`Invalid bump: ${bump}`);
+          ' "$CURRENT" "$BUMP")"
+          TAG="v$VERSION"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "mode=auto" >> "$GITHUB_OUTPUT"
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Stop when no release is required
+        if: steps.version.outputs.release != 'true'
+        run: echo "No release required for this push."
 
       - name: Install dependencies
+        if: steps.version.outputs.release == 'true'
         run: npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false
 
+      - name: Apply automatic version bump
+        if: steps.version.outputs.release == 'true' && steps.version.outputs.mode == 'auto'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          BUMP: ${{ steps.version.outputs.bump }}
+          MERGED_BRANCH: ${{ steps.version.outputs.branch }}
+          PR_NUMBER: ${{ steps.version.outputs.pr_number }}
+          PR_TITLE: ${{ steps.version.outputs.pr_title }}
+          PR_URL: ${{ steps.version.outputs.pr_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm version "$VERSION" --no-git-tag-version
+
+          node <<'NODE'
+          const fs = require("fs");
+
+          const version = process.env.VERSION;
+          const today = new Date().toISOString().slice(0, 10);
+          const branch = process.env.MERGED_BRANCH || "unknown";
+          const bump = process.env.BUMP || "unknown";
+          const prNumber = process.env.PR_NUMBER || "";
+          const prTitle = process.env.PR_TITLE || `Merged ${branch}`;
+          const prUrl = process.env.PR_URL || "";
+          const path = "CHANGELOG.md";
+          const changelog = fs.readFileSync(path, "utf8");
+          const unreleasedHeading = "## [Unreleased]";
+          const start = changelog.indexOf(unreleasedHeading);
+
+          if (start === -1) {
+            throw new Error("CHANGELOG.md must contain ## [Unreleased]");
+          }
+
+          const afterHeading = start + unreleasedHeading.length;
+          const nextMatch = changelog.slice(afterHeading).match(/\n## \[/);
+          const next = nextMatch ? afterHeading + nextMatch.index : changelog.length;
+          const before = changelog.slice(0, afterHeading);
+          const unreleasedBody = changelog.slice(afterHeading, next).trim();
+          const after = changelog.slice(next);
+          const prRef = prNumber ? `#${prNumber}` : branch;
+          const prLink = prUrl && prNumber ? ` ([#${prNumber}](${prUrl}))` : prNumber ? ` (#${prNumber})` : "";
+          const fallback = `### Changed\n\n- ${prTitle}${prLink}.\n`;
+          const releaseBody = unreleasedBody || fallback;
+          const section = `\n\n## [${version}] - ${today}\n\n${releaseBody}\n`;
+          const note = `<!-- Automatically released from ${branch} as a ${bump} bump${prRef ? ` via ${prRef}` : ""}. -->`;
+
+          fs.writeFileSync(path, `${before}\n${section}${note}\n${after.replace(/^\n+/, "\n")}`);
+          NODE
+
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore(release): $TAG [skip ci]"
+          git push origin HEAD:main
+          git tag "$TAG"
+          git push origin "$TAG"
+
       - name: Run CI
+        if: steps.version.outputs.release == 'true'
         run: npm run ci
 
       - name: Extract changelog
+        if: steps.version.outputs.release == 'true'
         shell: bash
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -79,7 +224,18 @@ jobs:
             exit 1
           fi
 
+      - name: Ensure manual release tag exists
+        if: steps.version.outputs.release == 'true' && steps.version.outputs.mode == 'manual'
+        shell: bash
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
       - name: Pack
+        if: steps.version.outputs.release == 'true'
         id: pack
         shell: bash
         run: |
@@ -89,6 +245,7 @@ jobs:
           echo "file=$FILE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm with trusted publishing
+        if: steps.version.outputs.release == 'true'
         shell: bash
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -100,6 +257,7 @@ jobs:
           npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
 
       - name: Publish to GitHub Packages
+        if: steps.version.outputs.release == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
         shell: bash
@@ -137,6 +295,7 @@ jobs:
           npm publish --registry="$REGISTRY"
 
       - name: Create or update GitHub Release
+        if: steps.version.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Added automatic release generation on `main` merges from `feat/*` and `fix/*` branches.
 - Switched npm release publishing from `NPM_TOKEN` to npm Trusted Publishing with provenance.
 
 ## [0.4.0] - 2026-05-01

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/github/stars/weauratech/pi-memctx?style=flat&color=yellow" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/github/v/release/weauratech/pi-memctx?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/github/v/release/weauratech/pi-memctx?sort=semver&label=release&style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -9,19 +9,27 @@ pi install git:github.com/weauratech/pi-memctx
 
 ## Release workflow
 
-Releases are tag-driven. Pushing a tag like `v0.3.0` runs `.github/workflows/release.yml`, which:
+Releases are generated automatically when a pull request is merged to `main` with a release branch prefix:
 
-1. validates that the tag version matches `package.json`;
-2. installs dependencies with `npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false`;
-3. runs `npm run ci`;
-4. extracts release notes from `CHANGELOG.md`;
-5. runs `npm pack --json`;
-6. generates a SHA-256 checksum for the tarball;
-7. publishes the tarball to npmjs.com with npm Trusted Publishing and provenance;
-8. publishes a scoped mirror to GitHub Packages as `@weauratech/pi-memctx` using `GITHUB_TOKEN`;
-9. creates or updates the GitHub Release and uploads the tarball plus checksum.
+- `feat/...` or `feature/...` creates a minor release;
+- `fix/...`, `bugfix/...`, or `hotfix/...` creates a patch release;
+- other branch prefixes run no release.
 
-The publish steps are idempotent: if the version already exists on a registry, publishing to that registry is skipped.
+The merge to `main` runs `.github/workflows/release.yml`, which:
+
+1. detects the merged pull request branch;
+2. bumps `package.json` and `package-lock.json` with `npm version --no-git-tag-version`;
+3. moves the `CHANGELOG.md` `Unreleased` notes into the new version section, or creates a release note from the merged PR;
+4. commits the release bump back to `main` and pushes the matching `vX.Y.Z` tag;
+5. installs dependencies with `npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false`;
+6. runs `npm run ci`;
+7. extracts release notes from `CHANGELOG.md`;
+8. runs `npm pack --json` and generates a SHA-256 checksum for the tarball;
+9. publishes the tarball to npmjs.com with npm Trusted Publishing and provenance;
+10. publishes a scoped mirror to GitHub Packages as `@weauratech/pi-memctx` using `GITHUB_TOKEN`;
+11. creates or updates the GitHub Release and uploads the tarball plus checksum.
+
+The workflow can also be run manually with a `vX.Y.Z` tag when the tag version already matches `package.json`. The publish steps are idempotent: if the version already exists on a registry, publishing to that registry is skipped.
 
 ## npm Trusted Publishing
 
@@ -66,17 +74,11 @@ pi install npm:pi-memctx
 1. Run `npm run ci`.
 2. Run `npm pack --dry-run --json` and inspect included files.
 3. Review `SECURITY.md` and ensure no sensitive data was committed.
-4. Update `CHANGELOG.md` with a section matching the release version, for example `## [0.3.0] - YYYY-MM-DD`.
-5. Update `package.json` and `package-lock.json` to the same version.
-6. Merge the release commit to `main`.
-7. Create and push the tag:
-
-```bash
-git checkout main
-git pull
-git tag v0.3.0
-git push origin v0.3.0
-```
+4. Add user-facing release notes under `## [Unreleased]` in `CHANGELOG.md`.
+5. Open the PR from a release branch prefix:
+   - `feat/...` for a minor release;
+   - `fix/...` for a patch release.
+6. Merge the PR to `main` with a merge commit so the release workflow can identify the source branch.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- trigger the Release workflow on pushes to main
- infer release type from the merged PR branch prefix
  - feat/feature => minor
  - fix/bugfix/hotfix => patch
- automatically bump package.json/package-lock.json, move Unreleased changelog notes, create the tag, publish to npm via Trusted Publishing, publish the GitHub Packages mirror, and create the GitHub Release
- fix the README release badge URL so it uses the semver-sorted GitHub release badge instead of showing invalid

## Validation
- ruby YAML parse for .github/workflows/release.yml
- README badge URL returns SVG
- npm run ci
- npm pack --dry-run --json