### PR TITLE
fix: use lockfile install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.version.outputs.release == 'true'
-        run: npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false
+        run: npm ci --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund
 
       - name: Apply automatic version bump
         if: steps.version.outputs.release == 'true' && steps.version.outputs.mode == 'auto'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Use deterministic release dependency installation from the lockfile.
 
 ## [0.5.0] - 2026-05-01
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -21,7 +21,7 @@ The merge to `main` runs `.github/workflows/release.yml`, which:
 2. bumps `package.json` and `package-lock.json` with `npm version --no-git-tag-version`;
 3. moves the `CHANGELOG.md` `Unreleased` notes into the new version section, or creates a release note from the merged PR;
 4. commits the release bump back to `main` and pushes the matching `vX.Y.Z` tag;
-5. installs dependencies with `npm install --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund --package-lock=false`;
+5. installs dependencies deterministically with `npm ci --omit=optional --omit=peer --ignore-scripts --no-audit --no-fund`;
 6. runs `npm run ci`;
 7. extracts release notes from `CHANGELOG.md`;
 8. runs `npm pack --json` and generates a SHA-256 checksum for the tarball;


### PR DESCRIPTION
## Summary
- switch the release workflow install step to npm ci so releases use the committed lockfile instead of resolving wildcard dependencies during publish
- document the deterministic install command
- add changelog note for the release workflow fix

## Validation
- ruby YAML parse for .github/workflows/release.yml
- npm run ci

## Context
The first automatic release run successfully bumped main to v0.5.0 and pushed tag v0.5.0, but publish did not complete. This fix allows the next fix/* merge to exercise the patch release path and publish v0.5.1.