### PR TITLE
fix: force trusted publishing auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
           cache: npm
 
       - uses: oven-sh/setup-bun@v2
@@ -254,6 +253,8 @@ jobs:
             exit 0
           fi
 
+          npm config delete //registry.npmjs.org/:_authToken || true
+          unset NODE_AUTH_TOKEN
           npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
 
       - name: Publish to GitHub Packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Force the npmjs.com publish step to use Trusted Publishing OIDC instead of any inherited long-lived token.
 
 ## [0.5.1] - 2026-05-01
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -44,7 +44,7 @@ Workflow file: release.yml
 Environment: npm
 ```
 
-The release workflow requests `id-token: write` and runs `npm publish --provenance --access public`, which lets npm exchange the GitHub Actions OIDC identity for a short-lived publish credential.
+The release workflow requests `id-token: write`, clears any long-lived npm auth token from the npmjs.com publish step, and runs `npm publish --provenance --access public`, which lets npm exchange the GitHub Actions OIDC identity for a short-lived publish credential.
 
 ## GitHub Packages mirror
 


### PR DESCRIPTION
## Summary
- remove npmjs registry auth setup from actions/setup-node
- clear any inherited npmjs auth token before `npm publish` so npm uses Trusted Publishing OIDC
- document the behavior and add a changelog note

## Validation
- ruby YAML parse for .github/workflows/release.yml
- npm run ci

## Context
The automatic release flow now bumps versions and creates tags correctly, but npm publish has been failing with E404 after signing provenance, which is consistent with npm using an inherited long-lived token instead of the configured trusted publisher identity. This change forces the publish step onto OIDC.