### PR TITLE
fix: upgrade npm for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11
+          npm --version
+
       - uses: oven-sh/setup-bun@v2
 
       - name: Configure git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade npm in the release workflow so Trusted Publishing OIDC authentication is supported.
 
 ## [0.5.2] - 2026-05-01
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -44,7 +44,7 @@ Workflow file: release.yml
 Environment: npm
 ```
 
-The release workflow requests `id-token: write`, clears any long-lived npm auth token from the npmjs.com publish step, and runs `npm publish --provenance --access public`, which lets npm exchange the GitHub Actions OIDC identity for a short-lived publish credential.
+The release workflow requests `id-token: write`, upgrades to npm 11 for Trusted Publishing support, clears any long-lived npm auth token from the npmjs.com publish step, and runs `npm publish --provenance --access public`, which lets npm exchange the GitHub Actions OIDC identity for a short-lived publish credential.
 
 ## GitHub Packages mirror
 


### PR DESCRIPTION
## Summary
- upgrade npm to v11 inside the release workflow before publishing
- keep npmjs publish free of long-lived auth tokens so Trusted Publishing OIDC can authenticate
- update publishing docs and changelog

## Validation
- ruby YAML parse for .github/workflows/release.yml
- npm run ci

## Context
The previous release run reached `npm publish` but npm reported ENEEDAUTH when no token was present. npm Trusted Publishing requires a recent npm CLI with OIDC support, so this upgrades npm in the workflow before publish.