### PR TITLE
fix: publish with npm eleven via npx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,6 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Upgrade npm for trusted publishing
-        run: |
-          npm install -g npm@11
-          npm --version
-
       - uses: oven-sh/setup-bun@v2
 
       - name: Configure git
@@ -260,7 +255,8 @@ jobs:
 
           npm config delete //registry.npmjs.org/:_authToken || true
           unset NODE_AUTH_TOKEN
-          npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
+          npx --yes npm@11 --version
+          npx --yes npm@11 publish "${{ steps.pack.outputs.file }}" --provenance --access public
 
       - name: Publish to GitHub Packages
         if: steps.version.outputs.release == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Run the npmjs.com publish through npm 11 without replacing the runner's bundled npm.
 - Upgrade npm in the release workflow so Trusted Publishing OIDC authentication is supported.
 
 ## [0.5.2] - 2026-05-01

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -44,7 +44,7 @@ Workflow file: release.yml
 Environment: npm
 ```
 
-The release workflow requests `id-token: write`, upgrades to npm 11 for Trusted Publishing support, clears any long-lived npm auth token from the npmjs.com publish step, and runs `npm publish --provenance --access public`, which lets npm exchange the GitHub Actions OIDC identity for a short-lived publish credential.
+The release workflow requests `id-token: write`, runs the npmjs.com publish through npm 11 for Trusted Publishing support, clears any long-lived npm auth token from the publish step, and runs `npm publish --provenance --access public`, which lets npm exchange the GitHub Actions OIDC identity for a short-lived publish credential.
 
 ## GitHub Packages mirror
 


### PR DESCRIPTION
## Summary
- run the npmjs.com publish command through `npx npm@11` instead of globally replacing npm on the runner
- keep npmjs auth token cleared so npm 11 can use Trusted Publishing OIDC
- update publishing docs and changelog

## Validation
- ruby YAML parse for .github/workflows/release.yml
- npm run ci