### PR TITLE
fix: repair readme release badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the README release badge URL so Shields renders the latest GitHub Release instead of `invalid`.
 
 ## [0.5.3] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/github/stars/weauratech/pi-memctx?style=flat&color=yellow" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/github/v/release/weauratech/pi-memctx?sort=semver&label=release&style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/github/v/release/weauratech/pi-memctx?label=release&style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- remove the unsupported Shields `sort=semver` query from the GitHub release badge
- keep the README badge pointed at the latest GitHub Release
- add changelog note

## Validation
- README badge URL returns `release: v0.5.3` SVG
- npm run ci