### PR TITLE
fix: repair readme stars badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the README stars badge by using a dynamic GitHub API count badge.
 
 ## [0.5.4] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/github/stars/weauratech/pi-memctx?style=flat&color=yellow" alt="Stars"></a>
+  <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
   <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/github/v/release/weauratech/pi-memctx?label=release&style=flat" alt="Latest Release"></a>


### PR DESCRIPTION
## Summary
- replace the broken Shields GitHub stars route with a dynamic JSON badge backed by the GitHub repository API
- keep the badge linked to the repository stargazers page
- add changelog note

## Validation
- stars badge URL returns `stars: 3` instead of `invalid`

Note: local `npm run ci` was attempted but the local `tsc` process hung in this environment; this PR only changes README/CHANGELOG and remote CI will validate the repo.