### PR TITLE
fix: sync readme release badge on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,9 +195,21 @@ jobs:
           const note = `<!-- Automatically released from ${branch} as a ${bump} bump${prRef ? ` via ${prRef}` : ""}. -->`;
 
           fs.writeFileSync(path, `${before}\n${section}${note}\n${after.replace(/^\n+/, "\n")}`);
+
+          const readmePath = "README.md";
+          const readme = fs.readFileSync(readmePath, "utf8");
+          const badgeUrl = `https://img.shields.io/badge/release-v${version}-blue?style=flat`;
+          const updatedReadme = readme.replace(
+            /<a href="https:\/\/github\.com\/weauratech\/pi-memctx\/releases\/latest"><img src="[^"]+" alt="Latest Release"><\/a>/,
+            `<a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="${badgeUrl}" alt="Latest Release"></a>`,
+          );
+          if (updatedReadme === readme) {
+            throw new Error("README.md latest release badge was not found");
+          }
+          fs.writeFileSync(readmePath, updatedReadme);
           NODE
 
-          git add package.json package-lock.json CHANGELOG.md
+          git add package.json package-lock.json CHANGELOG.md README.md
           git commit -m "chore(release): $TAG [skip ci]"
           git push origin HEAD:main
           git tag "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the README release badge in sync during automatic release bumps.
 
 ## [0.5.5] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/github/v/release/weauratech/pi-memctx?label=release&style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.5.5-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -20,14 +20,15 @@ The merge to `main` runs `.github/workflows/release.yml`, which:
 1. detects the merged pull request branch;
 2. bumps `package.json` and `package-lock.json` with `npm version --no-git-tag-version`;
 3. moves the `CHANGELOG.md` `Unreleased` notes into the new version section, or creates a release note from the merged PR;
-4. commits the release bump back to `main` and pushes the matching `vX.Y.Z` tag;
-5. installs dependencies with `npm install --omit=optional --ignore-scripts --no-audit --no-fund`, allowing npm to refresh peer metadata from the lockfile before the release bump;
-6. runs `npm run ci`;
-7. extracts release notes from `CHANGELOG.md`;
-8. runs `npm pack --json` and generates a SHA-256 checksum for the tarball;
-9. publishes the tarball to npmjs.com with npm Trusted Publishing and provenance;
-10. publishes a scoped mirror to GitHub Packages as `@weauratech/pi-memctx` using `GITHUB_TOKEN`;
-11. creates or updates the GitHub Release and uploads the tarball plus checksum.
+4. rewrites the README release badge to the exact `vX.Y.Z` being released, avoiding stale latest-release badge caches;
+5. commits the release bump back to `main` and pushes the matching `vX.Y.Z` tag;
+6. installs dependencies with `npm install --omit=optional --ignore-scripts --no-audit --no-fund`, allowing npm to refresh peer metadata from the lockfile before the release bump;
+7. runs `npm run ci`;
+8. extracts release notes from `CHANGELOG.md`;
+9. runs `npm pack --json` and generates a SHA-256 checksum for the tarball;
+10. publishes the tarball to npmjs.com with npm Trusted Publishing and provenance;
+11. publishes a scoped mirror to GitHub Packages as `@weauratech/pi-memctx` using `GITHUB_TOKEN`;
+12. creates or updates the GitHub Release and uploads the tarball plus checksum.
 
 The workflow can also be run manually with a `vX.Y.Z` tag when the tag version already matches `package.json`. The publish steps are idempotent: if the version already exists on a registry, publishing to that registry is skipped.
 


### PR DESCRIPTION
## Summary
- stop relying on the latest-release Shields endpoint for the README release badge
- pin the README release badge to the current release version
- update the automatic release bump to rewrite the README badge to the exact `vX.Y.Z` being released
- document the release badge sync in publishing docs

## Validation
- release workflow YAML parses successfully
- README release badge is pinned to current published version `v0.5.5`

Note: local `npm run ci` is currently hanging in this environment at `tsc --noEmit`; this PR changes release workflow/docs/README and remote CI will validate.