### PR TITLE
docs: update qmd-economy benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Updated README benchmark results for the `qmd-economy` profile with measured local latency, token, tool-call, and quality improvements.
+- Simplified benchmark defaults and docs to compare `baseline` against `qmd-economy` only.
 
 ## [0.6.0] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,17 @@ Agent: Based on your deploy runbook:
 
 Run `bash benchmark/setup.sh && bash benchmark/run.sh` to measure on your own project.
 
-Typical results across 5 common tasks:
+Latest local benchmark (`baseline` vs `qmd-economy`, 5 tasks, 1 repeat):
 
-| Metric | Without | With pi-memctx | Gain |
-|---|---|---|---|
-| Tool calls per task | ~6 | ~1 | **80% fewer** |
-| Correct facts in response | ~40% | ~95% | **2.4× better** |
-| Time to answer | ~30s | ~5s | **6× faster** |
-| Follow-up prompts needed | ~3 | ~0 | **First-pass accuracy** |
+| Metric | Baseline | qmd-economy | Gain |
+|---|---:|---:|---:|
+| Avg time to answer | 23.9s | 4.4s | **5.4× faster** |
+| Tool calls per task | 7.0 | 0.0 | **100% fewer** |
+| Quality facts found | 14/22 | 22/22 | **100% coverage** |
+| Provider tokens/task | 2,453 | 1,950 | **20% fewer** |
+| Visible tokens/task* | 545 | 175 | **68% fewer** |
+
+*Visible tokens are approximated from prompt + assistant text chars / 4. `qmd-economy` injects compact answer plans from qmd-backed fact cards, so the agent answers directly instead of exploring files or calling `memctx_search` for already-supported project questions.
 
 ### What this means for your team
 
@@ -266,7 +269,7 @@ These slash commands are available inside Pi after the extension loads.
 
 | Command | Usage | What |
 |---|---|---|
-| `/memctx-profile` | `/memctx-profile auto\|low\|balanced\|full\|status` | Apply a zero-config behavior profile. Default is `auto`. |
+| `/memctx-profile` | `/memctx-profile qmd-economy\|auto\|status` | Apply a zero-config behavior profile. Default is `auto`; `qmd-economy` is recommended for lowest tool/token usage. |
 | `/memctx-config` | `/memctx-config status\|reset` | Inspect or reset persistent config in `~/.config/pi-memctx/config.json`. |
 | `/memctx-pack` | `/memctx-pack` or `/memctx-pack <name>` | List packs with a picker or switch directly. |
 | `/memctx-pack-status` | `/memctx-pack-status` | Show active pack, profile/config, selection reason/confidence, last switch, qmd status, strict mode, LLM stats, file count, and last retrieval. |
@@ -285,25 +288,27 @@ Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, 
 ### `/memctx-pack-status` example
 
 ```txt
-Profile: auto
+Profile: qmd-economy
 Config path: ~/.config/pi-memctx/config.json
 Active pack: opensource
 Pack path: ~/.pi/agent/memory-vault/packs/opensource
 Auto-switch: cwd
-Retrieval policy: auto
-Retrieval budget: 1000ms
-Autosave: suggest
+Retrieval policy: fast
+Retrieval budget: 250ms
+Context pipeline: qmd-economy
+Context budget: 650 tokens
+Autosave: off
 Autosave low-confidence queue: off
 Save queue: 0 pending
 Selection: high (112)
 Last switch: none
 qmd: available
 qmd source: local-dependency
-Strict mode: on
-LLM mode: assist
+Strict mode: off
+LLM mode: off
 LLM calls: 0
-Overlay: 📦 opensource · profile:auto · qmd:3 · retrieval:auto · save:auto · strict:on · llm:assist
-Last retrieval: qmd
+Overlay: 📦 opensource · profile:qmd-economy · qmd:3 · ctx:650 · retrieval:fast · save:off · strict:off · llm:off
+Last retrieval: qmd-economy
 ```
 
 ### `/memctx-pack-generate` discovery
@@ -324,12 +329,11 @@ cd ~/code/my-infra     # → loads "infra" pack
 cd ~/code              # → loads org-level pack
 ```
 
-For most users, no setup is needed: `profile:auto` is applied by default. Switch profile when you want different trade-offs:
+For most users, no setup is needed: `profile:auto` is applied by default. Switch to `qmd-economy` when you want the lowest tool/token usage for project Q&A:
 
 ```txt
-/memctx-profile low       # low latency/cost
-/memctx-profile balanced  # review memory candidates
-/memctx-profile full      # maximum retrieval/LLM usage
+/memctx-profile qmd-economy  # compact qmd-backed answer plans, no autosave/LLM, fast retrieval
+/memctx-profile auto         # default general-purpose behavior
 ```
 
 Switch mid-session with `/memctx-pack`, or enable prompt-based switching:
@@ -372,9 +376,11 @@ Measure the impact on your own project:
 # Setup fictional test scenario
 bash benchmark/setup.sh
 
-# Run 5 tasks with and without pi-memctx
+# Run 5 tasks: baseline vs qmd-economy
 bash benchmark/run.sh
 ```
+
+Recent run (`20260501-180558`): `qmd-economy` answered all 5 tasks with **0 tool calls**, **22/22 quality facts**, **4.4s avg latency**, and **~175 visible tokens/task**. Baseline averaged 7 tool calls, 14/22 quality facts, 23.9s latency, and ~545 visible tokens/task.
 
 ## Documentation
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,7 +2,7 @@
 
 Measure the local impact of pi-memctx inside your own Pi CLI.
 
-The benchmark compares the same tasks with **no extensions** (`baseline`) and with pi-memctx loaded using a profile such as `full`. It does not add extension slash commands; it runs Pi in print mode with isolated environment variables.
+The benchmark compares the same tasks with **no extensions** (`baseline`) and with pi-memctx loaded using the `qmd-economy` profile. It does not add extension slash commands; it runs Pi in print mode with isolated environment variables.
 
 ## Quick start
 
@@ -10,14 +10,14 @@ The benchmark compares the same tasks with **no extensions** (`baseline`) and wi
 # 1. Setup fake project + pack
 bash benchmark/setup.sh
 
-# 2. Run local comparison: baseline vs profile:full
+# 2. Run local comparison: baseline vs qmd-economy
 bash benchmark/run.sh
 ```
 
 Optional:
 
 ```bash
-BENCH_REPEATS=2 BENCH_PROFILES="baseline auto full" bash benchmark/run.sh
+BENCH_REPEATS=2 BENCH_PROFILES="baseline qmd-economy" bash benchmark/run.sh
 BENCH_PI_MODEL="github-copilot/gpt-5.5" bash benchmark/run.sh
 ```
 
@@ -44,17 +44,18 @@ Each task runs for each selected profile.
 
 ## Expected results
 
-With pi-memctx:
-- **Fewer tool calls** — agent already has context, doesn't need to `find`/`grep`/`read`
+With `qmd-economy`:
+- **Zero or near-zero tool calls** — injected answer plans remove exploratory `find`/`grep`/`read` loops
 - **Higher quality** — knows architecture decisions, conventions, runbooks
-- **Faster responses** — less exploration, more direct answers
+- **Faster responses** — compact context produces direct answers instead of exploration
+- **Lower visible token usage** — concise fact cards reduce assistant output and follow-up prompts
 
 ## Output
 
 Results saved to `/tmp/pi-memctx-benchmark/results/`:
 
 - `*_baseline_r*.txt` — raw agent output without extensions
-- `*_full_r*.txt` — raw agent output with pi-memctx profile `full`
+- `*_qmd-economy_r*.txt` — raw agent output with pi-memctx profile `qmd-economy`
 - `*_metrics.json` — structured metrics per task/profile/repeat
 - `summary-<run-id>.jsonl` — machine-readable aggregate rows
 - `report-<run-id>.md` — human-readable report
@@ -64,4 +65,4 @@ Results saved to `/tmp/pi-memctx-benchmark/results/`:
 - The baseline uses `--no-extensions` so globally installed pi-memctx does not leak into the baseline.
 - The memctx run uses `--no-extensions -e <repo>` so only the local extension under test is loaded.
 - Profile config is isolated per run with `MEMCTX_CONFIG_PATH`.
-- Token counts are approximate visible tokens. Provider-side system/context/cache token usage requires provider/Pi usage instrumentation and is not included in this local script.
+- Visible token counts are approximate. Provider token usage is captured from Pi JSON usage events when the selected provider/model reports it; otherwise those fields may be zero.

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run a local pi benchmark: same tasks WITHOUT memctx and WITH pi-memctx profile:full.
+# Run a local pi benchmark: same tasks WITHOUT memctx and WITH pi-memctx qmd-economy.
 # Captures JSON-mode events so tool calls and provider token usage can be measured.
 #
 # Usage:
@@ -7,17 +7,17 @@
 #   bash benchmark/run.sh [base_dir]
 #
 # Optional env:
-#   BENCH_PROFILES="baseline full"   # default
-#   BENCH_REPEATS=2                  # default
-#   BENCH_PI_MODEL="provider/model"  # optional pass-through to pi --model
-#   BENCH_TIMEOUT=180                # seconds per task
+#   BENCH_PROFILES="baseline qmd-economy"  # default
+#   BENCH_REPEATS=2                         # default
+#   BENCH_PI_MODEL="provider/model"         # optional pass-through to pi --model
+#   BENCH_TIMEOUT=180                       # seconds per task
 
 set -euo pipefail
 
 BASE_DIR="${1:-/tmp/pi-memctx-benchmark}"
 RESULTS_DIR="$BASE_DIR/results"
 EXTENSION_PATH="$(cd "$(dirname "$0")/.." && pwd)"
-BENCH_PROFILES="${BENCH_PROFILES:-baseline full}"
+BENCH_PROFILES="${BENCH_PROFILES:-baseline qmd-economy}"
 BENCH_REPEATS="${BENCH_REPEATS:-2}"
 BENCH_TIMEOUT="${BENCH_TIMEOUT:-180}"
 BENCH_RUN_ID="$(date +%Y%m%d-%H%M%S)"
@@ -58,60 +58,6 @@ profile_config() {
   local profile="$1"
   local config_path="$2"
   case "$profile" in
-    full)
-      cat > "$config_path" <<'JSON'
-{
-  "profile": "full",
-  "baseProfile": "full",
-  "strict": true,
-  "retrieval": "strict",
-  "retrievalLatencyBudgetMs": 3000,
-  "autosave": "auto",
-  "autosaveQueueLowConfidence": false,
-  "llm": "first",
-  "autoSwitch": "all",
-  "autoBootstrap": "ask",
-  "startupDoctor": "full",
-  "toolFailureHints": true
-}
-JSON
-      ;;
-    auto)
-      cat > "$config_path" <<'JSON'
-{
-  "profile": "auto",
-  "baseProfile": "auto",
-  "strict": true,
-  "retrieval": "auto",
-  "retrievalLatencyBudgetMs": 1000,
-  "autosave": "auto",
-  "autosaveQueueLowConfidence": false,
-  "llm": "assist",
-  "autoSwitch": "all",
-  "autoBootstrap": "ask",
-  "startupDoctor": "light",
-  "toolFailureHints": true
-}
-JSON
-      ;;
-    low)
-      cat > "$config_path" <<'JSON'
-{
-  "profile": "low",
-  "baseProfile": "low",
-  "strict": false,
-  "retrieval": "fast",
-  "retrievalLatencyBudgetMs": 300,
-  "autosave": "off",
-  "autosaveQueueLowConfidence": false,
-  "llm": "off",
-  "autoSwitch": "cwd",
-  "autoBootstrap": "ask",
-  "startupDoctor": "off",
-  "toolFailureHints": false
-}
-JSON
-      ;;
     qmd-economy)
       cat > "$config_path" <<'JSON'
 {
@@ -135,25 +81,7 @@ JSON
 }
 JSON
       ;;
-    balanced)
-      cat > "$config_path" <<'JSON'
-{
-  "profile": "balanced",
-  "baseProfile": "balanced",
-  "strict": true,
-  "retrieval": "balanced",
-  "retrievalLatencyBudgetMs": 1000,
-  "autosave": "suggest",
-  "autosaveQueueLowConfidence": false,
-  "llm": "assist",
-  "autoSwitch": "all",
-  "autoBootstrap": "ask",
-  "startupDoctor": "light",
-  "toolFailureHints": true
-}
-JSON
-      ;;
-    *) echo "Unknown profile: $profile" >&2; return 1 ;;
+    *) echo "Unknown profile for benchmark: $profile (supported: baseline qmd-economy)" >&2; return 1 ;;
   esac
 }
 
@@ -389,7 +317,7 @@ PY
 cat <<HEADER
 
 ═══════════════════════════════════════════════════
-  pi-memctx Local Benchmark: baseline vs profiles
+  pi-memctx Local Benchmark: baseline vs qmd-economy
 ═══════════════════════════════════════════════════
 
 Base dir:     $BASE_DIR
@@ -418,7 +346,7 @@ write_report
 echo ""
 echo "Results JSONL: $SUMMARY_JSONL"
 echo "Report:       $SUMMARY_MD"
-echo "Raw JSONL:     $RESULTS_DIR/*_{baseline,full}_r*.jsonl"
-echo "Raw text:      $RESULTS_DIR/*_{baseline,full}_r*.txt"
+echo "Raw JSONL:     $RESULTS_DIR/*_r*.jsonl"
+echo "Raw text:      $RESULTS_DIR/*_r*.txt"
 echo ""
 cat "$SUMMARY_MD"


### PR DESCRIPTION
## Summary
- update README with measured qmd-economy benchmark results
- make benchmark default compare baseline vs qmd-economy only
- document qmd-economy benchmark output and add changelog notes

## Validation
- npm run ci
- npm pack --dry-run --json
- BENCH_PROFILES="baseline qmd-economy" BENCH_REPEATS=1 BENCH_TIMEOUT=180 bash benchmark/run.sh /tmp/pi-memctx-benchmark