### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.7.0] - 2026-05-02
+
+### Added
+
+- Added the Memory Gateway runtime with `gateway-lite`, `gateway`, and `gateway-full` profiles.
+- Added cheap semantic candidate ranking and local memory summaries for compact, high-signal context injection.
+- Added `npx pi-memctx doctor` and improved qmd binary resolution.
+
+### Changed
+
+- Reworked the default experience around gateway-based memory evaluation instead of direct answer-plan injection.
+- Updated benchmark tooling and documentation for baseline, gateway-lite, and gateway-full comparisons.
+- Rewrote the README for the new open-source Memory Gateway architecture and latest benchmark results.
+
+
 ## [0.6.1] - 2026-05-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.6.1-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.7.0-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- Bump package version to 0.7.0.
- Add changelog notes for the Memory Gateway release.
- Update README release badge.

## Validation
- npm run ci
