### PR TITLE
fix: migrate retired profile overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.7.2] - 2026-05-02
+
+### Fixed
+
+- Migrate retired persisted profiles such as `qmd-economy`, `low`, `balanced`, `auto`, and `full` to the closest gateway profile so the status overlay no longer reports stale `ctx:qmd-economy` after upgrading.
+
+
 ## [0.7.1] - 2026-05-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.7.1-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.7.2-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/index.ts
+++ b/index.ts
@@ -300,9 +300,15 @@ function profileDefaults(profile: Exclude<MemctxProfile, "custom">): MemctxConfi
 function normalizeProfileName(value: unknown): MemctxProfile {
 	const name = String(value ?? "gateway").toLowerCase();
 	if (["gateway-lite", "gateway", "gateway-full", "custom"].includes(name)) return name as MemctxProfile;
-	// Retired profile compatibility: all old modes now route through the gateway runtime.
-	if (["low", "balanced", "auto", "full", "qmd-economy"].includes(name)) return "gateway";
+	// Retired profile compatibility: old modes route to the closest gateway profile.
+	if (["low", "qmd-economy"].includes(name)) return "gateway-lite";
+	if (["full"].includes(name)) return "gateway-full";
+	if (["balanced", "auto"].includes(name)) return "gateway";
 	return "gateway";
+}
+
+function isRetiredProfileName(value: unknown): boolean {
+	return ["low", "balanced", "auto", "full", "qmd-economy"].includes(String(value ?? "").toLowerCase());
 }
 
 function readMemctxConfig(): MemctxConfig {
@@ -313,6 +319,9 @@ function readMemctxConfig(): MemctxConfig {
 		const parsed = JSON.parse(raw) as Partial<MemctxConfig>;
 		const profile = normalizeProfileName(parsed.profile);
 		const base = (profile === "custom" ? normalizeProfileName(parsed.baseProfile) : profile) as Exclude<MemctxProfile, "custom">;
+		if (isRetiredProfileName(parsed.profile)) {
+			return profileDefaults(base);
+		}
 		return { ...profileDefaults(base), ...parsed, profile, baseProfile: base };
 	} catch {
 		return fallback;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- Migrate persisted retired profiles to the closest gateway profile.
- Prevent upgraded installs from keeping stale qmd-economy context pipeline in the overlay.
- Bump to v0.7.2 with changelog and README badge updates.

## Validation
- npm run ci
