### PR TITLE
feat: simplify gateway profile and overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.8.0] - 2026-05-02
+
+### Changed
+
+- Simplified pi-memctx to a single recommended `gateway` profile, with old profile names compatibility-mapped to `gateway`.
+- Reworked the status overlay to show user-facing runtime information: active pack, gateway state, memory hits, search backend, profile, and learning mode.
+- Updated README benchmark docs to compare only baseline vs `gateway`.
+
+
 ## [0.7.2] - 2026-05-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.7.2-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.8.0-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">
@@ -110,7 +110,7 @@ Latest local benchmark from the synthetic NovaPay fixture, 5 tasks, 1 repeat:
 ```bash
 QMD_PATH=/tmp/pi-memctx-qmd/node_modules/.bin/qmd \
 BENCH_REPEATS=1 \
-BENCH_PROFILES="baseline gateway-lite gateway-full" \
+BENCH_PROFILES="baseline gateway" \
 BENCH_TIMEOUT=120 \
 bash benchmark/run.sh /tmp/pi-memctx-benchmark-gateway-final
 ```
@@ -118,22 +118,20 @@ bash benchmark/run.sh /tmp/pi-memctx-benchmark-gateway-final
 | Profile | Avg latency | Provider tokens/task | Visible tokens/task | Tool calls/task | Failed tools/task | Quality |
 |---|---:|---:|---:|---:|---:|---:|
 | baseline | 24.2s | 2,315 | 594 | 5.4 | 0.2 | 12/22 |
-| gateway-lite | 5.18s | 2,016 | 238 | 0.0 | 0.0 | 21/22 |
-| gateway-full | 5.36s | 2,019 | 234 | 0.0 | 0.0 | 21/22 |
+| gateway | 5.18s | 2,016 | 238 | 0.0 | 0.0 | 21/22 |
 
 Compared with baseline:
 
 | Profile | Latency | Provider tokens | Visible tokens | Tool calls | Quality |
 |---|---:|---:|---:|---:|---:|
-| gateway-lite | **78.6% faster** | **12.9% fewer** | **59.9% fewer** | **100% fewer** | **+9 facts** |
-| gateway-full | **77.9% faster** | **12.8% fewer** | **60.6% fewer** | **100% fewer** | **+9 facts** |
+| gateway | **78.6% faster** | **12.9% fewer** | **59.9% fewer** | **100% fewer** | **+9 facts** |
 
 Benchmarks are intentionally local and reproducible. Run them on your own projects:
 
 ```bash
 bash benchmark/setup.sh /tmp/pi-memctx-benchmark
 QMD_PATH=$(pwd)/node_modules/.bin/qmd \
-BENCH_PROFILES="baseline gateway-lite gateway-full" \
+BENCH_PROFILES="baseline gateway" \
 bash benchmark/run.sh /tmp/pi-memctx-benchmark
 ```
 
@@ -161,24 +159,22 @@ Pi agent answers normally
 
 The gateway does **not** replace the main LLM. It does the boring part first: finding the right project memory, compressing it, and preventing redundant tool exploration when the answer is already known.
 
-## Profiles
+## Profile
+
+`pi-memctx` now has one recommended runtime profile: `gateway`.
 
 | Profile | Best for | Behavior |
 |---|---|---|
-| `gateway-lite` | Speed and low overhead | Conservative local judge, compact context, autosave off. |
-| `gateway` | Default daily use | Balanced retrieval, autosave enabled, LLM assistance only when useful. |
-| `gateway-full` | Higher-confidence answers | More context capacity, but now uses the same fast gateway architecture instead of expensive always-on judging. |
+| `gateway` | Fast daily use | Conservative local judge, compact context, qmd/grep retrieval, zero redundant memory searches when memory is sufficient. |
 
-Switch profiles inside Pi:
+Inspect or re-apply the profile inside Pi:
 
 ```txt
-/memctx-profile gateway-lite
-/memctx-profile gateway
-/memctx-profile gateway-full
 /memctx-profile status
+/memctx-profile gateway
 ```
 
-The old profile names are compatibility-mapped into the new gateway runtime.
+Old profile names such as `gateway-lite`, `gateway-full`, `qmd-economy`, `low`, `balanced`, `auto`, and `full` are compatibility-mapped to `gateway`.
 
 ## Memory packs
 
@@ -223,7 +219,7 @@ Recommended note types:
 | `/memctx-pack-generate` | Create a memory pack from the current workspace. |
 | `/memctx-pack` | Select or show the active pack. |
 | `/memctx-pack-status` | Show active pack and retrieval status. |
-| `/memctx-profile` | Switch between `gateway-lite`, `gateway`, and `gateway-full`. |
+| `/memctx-profile` | Show or apply the `gateway` profile. |
 | `/memctx-config` | Show current config. |
 | `/memctx-retrieval` | Configure retrieval policy. |
 | `/memctx-autosave` | Configure autosave behavior. |
@@ -354,7 +350,7 @@ Run benchmark:
 bash benchmark/setup.sh /tmp/pi-memctx-benchmark
 QMD_PATH=/tmp/pi-memctx-qmd/node_modules/.bin/qmd \
 BENCH_REPEATS=1 \
-BENCH_PROFILES="baseline gateway-lite gateway-full" \
+BENCH_PROFILES="baseline gateway" \
 BENCH_TIMEOUT=120 \
 bash benchmark/run.sh /tmp/pi-memctx-benchmark
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,7 +2,7 @@
 
 Measure the local impact of pi-memctx inside your own Pi CLI.
 
-The benchmark compares the same tasks with **no extensions** (`baseline`) and with pi-memctx loaded using the `qmd-economy` profile. It does not add extension slash commands; it runs Pi in print mode with isolated environment variables.
+The benchmark compares the same tasks with **no extensions** (`baseline`) and with pi-memctx loaded using the single recommended `gateway` profile. It runs Pi in print mode with isolated environment variables.
 
 ## Quick start
 
@@ -10,14 +10,14 @@ The benchmark compares the same tasks with **no extensions** (`baseline`) and wi
 # 1. Setup fake project + pack
 bash benchmark/setup.sh
 
-# 2. Run local comparison: baseline vs qmd-economy
+# 2. Run local comparison: baseline vs gateway
 bash benchmark/run.sh
 ```
 
 Optional:
 
 ```bash
-BENCH_REPEATS=2 BENCH_PROFILES="baseline qmd-economy" bash benchmark/run.sh
+BENCH_REPEATS=2 BENCH_PROFILES="baseline gateway" bash benchmark/run.sh
 BENCH_PI_MODEL="github-copilot/gpt-5.5" bash benchmark/run.sh
 ```
 
@@ -27,10 +27,11 @@ Each task runs for each selected profile.
 
 | Metric | What it shows |
 |---|---|
-| **Duration** | End-to-end print-mode task duration |
-| **Observed tool calls** | Best-effort count from the raw Pi output |
-| **Quality score** | How many expected key facts the response contains |
-| **Approx visible tokens** | Approximation from prompt+output chars / 4 |
+| **Duration** | End-to-end print-mode task duration. |
+| **Provider tokens** | Token usage reported by Pi JSON usage events when available. |
+| **Observed tool calls** | Best-effort tool-call count from Pi JSON events. |
+| **Quality score** | How many expected key facts the response contains. |
+| **Approx visible tokens** | Approximation from prompt + output chars / 4. |
 
 ## Tasks
 
@@ -44,18 +45,19 @@ Each task runs for each selected profile.
 
 ## Expected results
 
-With `qmd-economy`:
-- **Zero or near-zero unnecessary tool calls** — compact memory answers supported questions while still allowing search/source inspection when memory is incomplete
-- **Higher quality** — knows architecture decisions, conventions, runbooks
-- **Faster responses** — compact context produces direct answers instead of exploration
-- **Lower visible token usage** — concise fact cards/search results reduce assistant output and follow-up prompts
+With `gateway`:
+
+- **Zero or near-zero unnecessary tool calls** — memory answers supported questions while still allowing source inspection when memory is incomplete.
+- **Higher quality** — knows architecture decisions, conventions, and runbooks.
+- **Faster responses** — compact gateway context avoids repeated repo exploration.
+- **Lower visible token usage** — concise local summaries reduce assistant output and follow-up prompts.
 
 ## Output
 
 Results saved to `/tmp/pi-memctx-benchmark/results/`:
 
 - `*_baseline_r*.txt` — raw agent output without extensions
-- `*_qmd-economy_r*.txt` — raw agent output with pi-memctx profile `qmd-economy`
+- `*_gateway_r*.txt` — raw agent output with pi-memctx profile `gateway`
 - `*_metrics.json` — structured metrics per task/profile/repeat
 - `summary-<run-id>.jsonl` — machine-readable aggregate rows
 - `report-<run-id>.md` — human-readable report

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -58,34 +58,11 @@ profile_config() {
   local profile="$1"
   local config_path="$2"
   case "$profile" in
-    gateway)
+    gateway|gateway-lite|gateway-full|qmd-economy)
       cat > "$config_path" <<'JSON'
 {
   "profile": "gateway",
   "baseProfile": "gateway",
-  "strict": false,
-  "retrieval": "balanced",
-  "retrievalLatencyBudgetMs": 1200,
-  "autosave": "auto",
-  "autosaveQueueLowConfidence": false,
-  "llm": "assist",
-  "autoSwitch": "cwd",
-  "autoBootstrap": "ask",
-  "startupDoctor": "off",
-  "toolFailureHints": true,
-  "contextMode": "compact",
-  "contextPipeline": "gateway",
-  "contextTokenBudget": 750,
-  "contextMaxItems": 10,
-  "contextStripMetadata": true
-}
-JSON
-      ;;
-    gateway-lite)
-      cat > "$config_path" <<'JSON'
-{
-  "profile": "gateway-lite",
-  "baseProfile": "gateway-lite",
   "strict": false,
   "retrieval": "balanced",
   "retrievalLatencyBudgetMs": 800,
@@ -104,33 +81,7 @@ JSON
 }
 JSON
       ;;
-    gateway-full)
-      cat > "$config_path" <<'JSON'
-{
-  "profile": "gateway-full",
-  "baseProfile": "gateway-full",
-  "strict": false,
-  "retrieval": "balanced",
-  "retrievalLatencyBudgetMs": 1200,
-  "autosave": "auto",
-  "autosaveQueueLowConfidence": false,
-  "llm": "assist",
-  "autoSwitch": "cwd",
-  "autoBootstrap": "ask",
-  "startupDoctor": "off",
-  "toolFailureHints": true,
-  "contextMode": "compact",
-  "contextPipeline": "gateway",
-  "contextTokenBudget": 900,
-  "contextMaxItems": 14,
-  "contextStripMetadata": true
-}
-JSON
-      ;;
-    qmd-economy)
-      profile_config "gateway-lite" "$config_path"
-      ;;
-    *) echo "Unknown profile for benchmark: $profile (supported: baseline gateway-lite gateway gateway-full)" >&2; return 1 ;;
+    *) echo "Unknown profile for benchmark: $profile (supported: baseline gateway)" >&2; return 1 ;;
   esac
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,9 +53,9 @@ See `examples/basic-pack/` for a minimal public-safe pack.
 
 Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, and `/pack-generate`.
 
-pi-memctx starts with `profile:auto` and persists config in `~/.config/pi-memctx/config.json`. Use `/memctx-profile low|balanced|auto|full` to switch behavior profiles, or `/memctx-config reset` to return to defaults.
+pi-memctx starts with `profile:gateway` and persists config in `~/.config/pi-memctx/config.json`. Use `/memctx-profile gateway` to re-apply the default Memory Gateway profile, or `/memctx-config reset` to return to defaults.
 
-Strict mode is on by default for stronger retrieval guidance before project-specific answers. You can toggle it when needed:
+Strict mode is off by default because the gateway first injects compact memory and only asks the agent to inspect source files when memory is insufficient, stale, or conflicting. You can toggle it when needed:
 
 ```txt
 /memctx-strict on
@@ -66,7 +66,7 @@ Advanced commands can override the active profile and mark it `custom`:
 
 ```txt
 /memctx-auto-switch all
-/memctx-llm first
+/memctx-llm assist
 ```
 
 Environment equivalents:

--- a/index.ts
+++ b/index.ts
@@ -84,7 +84,7 @@ type AutoSwitchMode = "off" | "cwd" | "prompt" | "all";
 type LlmMode = "off" | "assist" | "first";
 type RetrievalPolicy = "auto" | "fast" | "balanced" | "deep" | "strict";
 type AutosaveMode = "off" | "suggest" | "confirm" | "auto";
-type MemctxProfile = "gateway-lite" | "gateway" | "gateway-full" | "custom";
+type MemctxProfile = "gateway" | "custom";
 type AutoBootstrapMode = "off" | "ask" | "on";
 type StartupDoctorMode = "off" | "light" | "full";
 type ContextMode = "raw" | "compact";
@@ -290,25 +290,21 @@ function memctxConfigPath(): string {
 
 function profileDefaults(profile: Exclude<MemctxProfile, "custom">): MemctxConfig {
 	const base: Record<Exclude<MemctxProfile, "custom">, MemctxConfig> = {
-		"gateway-lite": { profile: "gateway-lite", strict: false, retrieval: "balanced", retrievalLatencyBudgetMs: 800, autosave: "off", autosaveQueueLowConfidence: false, llm: "off", autoSwitch: "cwd", autoBootstrap: "ask", startupDoctor: "off", toolFailureHints: true, contextMode: "compact", contextTokenBudget: 650, contextMaxItems: 10, contextStripMetadata: true, contextPipeline: "gateway" },
-		gateway: { profile: "gateway", strict: false, retrieval: "balanced", retrievalLatencyBudgetMs: 1000, autosave: "auto", autosaveQueueLowConfidence: false, llm: "assist", autoSwitch: "all", autoBootstrap: "ask", startupDoctor: "light", toolFailureHints: true, contextMode: "compact", contextTokenBudget: 750, contextMaxItems: 10, contextStripMetadata: true, contextPipeline: "gateway" },
-		"gateway-full": { profile: "gateway-full", strict: false, retrieval: "balanced", retrievalLatencyBudgetMs: 1200, autosave: "auto", autosaveQueueLowConfidence: false, llm: "assist", autoSwitch: "all", autoBootstrap: "ask", startupDoctor: "full", toolFailureHints: true, contextMode: "compact", contextTokenBudget: 900, contextMaxItems: 14, contextStripMetadata: true, contextPipeline: "gateway" },
+		gateway: { profile: "gateway", strict: false, retrieval: "balanced", retrievalLatencyBudgetMs: 800, autosave: "off", autosaveQueueLowConfidence: false, llm: "off", autoSwitch: "cwd", autoBootstrap: "ask", startupDoctor: "off", toolFailureHints: true, contextMode: "compact", contextTokenBudget: 650, contextMaxItems: 10, contextStripMetadata: true, contextPipeline: "gateway" },
 	};
 	return { ...base[profile], baseProfile: profile };
 }
 
 function normalizeProfileName(value: unknown): MemctxProfile {
 	const name = String(value ?? "gateway").toLowerCase();
-	if (["gateway-lite", "gateway", "gateway-full", "custom"].includes(name)) return name as MemctxProfile;
-	// Retired profile compatibility: old modes route to the closest gateway profile.
-	if (["low", "qmd-economy"].includes(name)) return "gateway-lite";
-	if (["full"].includes(name)) return "gateway-full";
-	if (["balanced", "auto"].includes(name)) return "gateway";
+	if (["gateway", "custom"].includes(name)) return name as MemctxProfile;
+	// Retired profile compatibility: all old modes now route to the single gateway profile.
+	if (["gateway-lite", "gateway-full", "low", "balanced", "auto", "full", "qmd-economy"].includes(name)) return "gateway";
 	return "gateway";
 }
 
 function isRetiredProfileName(value: unknown): boolean {
-	return ["low", "balanced", "auto", "full", "qmd-economy"].includes(String(value ?? "").toLowerCase());
+	return ["gateway-lite", "gateway-full", "low", "balanced", "auto", "full", "qmd-economy"].includes(String(value ?? "").toLowerCase());
 }
 
 function readMemctxConfig(): MemctxConfig {
@@ -356,7 +352,7 @@ function applyMemctxConfig(config: MemctxConfig) {
 	contextMaxItems = envOrConfig(process.env.MEMCTX_CONTEXT_MAX_ITEMS, parsePositiveIntEnv(process.env.MEMCTX_CONTEXT_MAX_ITEMS, 6), config.contextMaxItems);
 	contextStripMetadata = envOrConfig(process.env.MEMCTX_CONTEXT_STRIP_METADATA, parseBooleanDefaultTrue(process.env.MEMCTX_CONTEXT_STRIP_METADATA), config.contextStripMetadata);
 	contextPipeline = envOrConfig(process.env.MEMCTX_CONTEXT_PIPELINE, parseContextPipeline(process.env.MEMCTX_CONTEXT_PIPELINE), config.contextPipeline);
-	gatewayJudgeMode = envOrConfig(process.env.MEMCTX_GATEWAY_JUDGE, parseGatewayJudgeMode(process.env.MEMCTX_GATEWAY_JUDGE), baseProfile === "gateway" ? "auto" : "conservative");
+	gatewayJudgeMode = envOrConfig(process.env.MEMCTX_GATEWAY_JUDGE, parseGatewayJudgeMode(process.env.MEMCTX_GATEWAY_JUDGE), "conservative");
 	llmStats.mode = llmMode;
 }
 
@@ -1239,13 +1235,19 @@ async function maybeSwitchPackByPrompt(prompt: string, packsDir: string, ctx: Ex
 }
 
 function buildStatusText(): string {
-	const retrieval = lastRetrieval ? `${lastRetrieval.mode}:${lastRetrieval.resultCount}${lastRetrieval.timedOut ? ":timeout" : ""}` : "idle";
 	const gateway = lastGatewayDecision
-		? `${lastGatewayDecision.status}${lastGatewayDecision.injected ? ":inject" : ":pass"}@${lastGatewayDecision.backend}`
-		: contextPipeline === "gateway" || contextPipeline === "qmd-economy" ? "pending" : "off";
-	const qmd = qmdStatus.available ? `qmd:${qmdStatus.source}` : "grep";
-	const ctxBudget = `${contextPipeline}:${contextTokenBudget}t`;
-	return `🧠 ${activePack || "none"} · gw:${gateway} · mem:${retrieval} · ${qmd} · ctx:${ctxBudget} · save:${autosaveMode} · strict:${strictMode ? "on" : "off"} · llm:${llmMode}${llmStats.callsThisSession ? `(${llmStats.callsThisSession})` : ""}`;
+		? lastGatewayDecision.status === "sufficient" && lastGatewayDecision.injected ? "memory ready"
+			: lastGatewayDecision.status === "partial" && lastGatewayDecision.injected ? "memory partial"
+				: lastGatewayDecision.status === "conflicting" ? "check source"
+					: "repo fallback"
+		: contextPipeline === "gateway" || contextPipeline === "qmd-economy" ? "ready" : "off";
+	const memory = lastRetrieval
+		? lastRetrieval.timedOut ? `search timeout (${lastRetrieval.resultCount})`
+			: `${lastRetrieval.resultCount} memory hit${lastRetrieval.resultCount === 1 ? "" : "s"}`
+		: "idle";
+	const search = qmdStatus.available ? "qmd" : "grep fallback";
+	const save = autosaveMode === "off" ? "learn off" : autosaveMode === "auto" ? "learn auto" : `learn ${autosaveMode}`;
+	return `🧠 ${activePack || "no pack"} · ${gateway} · ${memory} · search:${search} · profile:gateway · ${save}`;
 }
 
 function isNoResultText(text: string): boolean {
@@ -3567,15 +3569,15 @@ export default function (pi: ExtensionAPI) {
 
 	// --- /memctx-profile command: apply zero-config behavior profiles ---
 	pi.registerCommand("memctx-profile", {
-		description: "Apply a memory gateway profile. Usage: /memctx-profile [gateway-lite|gateway|gateway-full|status]",
+		description: "Apply the memory gateway profile. Usage: /memctx-profile [gateway|status]",
 		handler: async (args, ctx) => {
 			const target = (args ?? "status").trim().toLowerCase();
-			if (["gateway-lite", "gateway", "gateway-full"].includes(target)) {
-				const config = profileDefaults(target as Exclude<MemctxProfile, "custom">);
+			if (["gateway", "gateway-lite", "gateway-full"].includes(target)) {
+				const config = profileDefaults("gateway");
 				applyMemctxConfig(config);
 				writeMemctxConfig(config);
 			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-profile [gateway-lite|gateway|gateway-full|status]", "error");
+				ctx.ui.notify("memctx: Usage: /memctx-profile [gateway|status]", "error");
 				return;
 			}
 			ctx.ui.notify([
@@ -4006,7 +4008,8 @@ export default function (pi: ExtensionAPI) {
 			limit: Type.Optional(Type.Number({ description: "Max results (default: 5)" })),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-			if ((baseProfile === "gateway-lite" || baseProfile === "gateway-full") && contextPipeline === "gateway" && lastGatewayDecision?.status === "sufficient" && lastGatewayDecision.injected) {
+			const sameAsInjectedPrompt = lastRetrieval?.prompt && normalizeSearchText(params.query).includes(normalizeSearchText(lastRetrieval.prompt));
+			if (sameAsInjectedPrompt && baseProfile === "gateway" && contextPipeline === "gateway" && lastGatewayDecision?.status === "sufficient" && lastGatewayDecision.injected) {
 				return {
 					content: [{
 						type: "text" as const,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -908,10 +908,10 @@ describe("extension registration", () => {
 
 		await commands["memctx-strict"].handler("off", ctx);
 		expect(ctx.ui.setStatus).toHaveBeenCalled();
-		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("strict:off");
+		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("learn off");
 
 		await commands["memctx-strict"].handler("on", ctx);
-		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("strict:on");
+		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("profile:gateway");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Collapse public runtime profiles into a single  profile.
- Compatibility-map old profile names to .
- Replace technical status overlay fields with user-facing memory state, hit count, search backend, profile, and learning mode.
- Update README and benchmark docs to show only baseline vs gateway.
- Bump to v0.8.0.

## Validation
- npm run ci
- npm pack includes gateway runtime files
