### PR TITLE
fix: run pack enrich in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.8.1] - 2026-05-02
+
+### Fixed
+
+- Run `/memctx-pack-enrich` as a guarded background job so the Pi terminal remains responsive while enrichment and qmd indexing continue.
+
+
 ## [0.8.0] - 2026-05-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.8.0-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.8.1-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/index.ts
+++ b/index.ts
@@ -201,6 +201,7 @@ let contextPipeline: ContextPipeline = parseContextPipeline(process.env.MEMCTX_C
 let qmdStatus: QmdStatus = { available: false, source: "missing" };
 let lastRetrieval: RetrievalStatus | null = null;
 let lastGatewayDecision: GatewayDecisionStatus | null = null;
+let packEnrichRunning = false;
 let autoSwitchMode: AutoSwitchMode = parseAutoSwitchMode(process.env.MEMCTX_AUTO_SWITCH);
 let llmMode: LlmMode = parseLlmMode(process.env.MEMCTX_LLM_MODE);
 let retrievalPolicy: RetrievalPolicy = parseRetrievalPolicy(process.env.MEMCTX_RETRIEVAL);
@@ -3790,10 +3791,14 @@ export default function (pi: ExtensionAPI) {
 
 	// --- /memctx-pack-enrich command: enrich existing pack with LLM/qmd notes ---
 	pi.registerCommand("memctx-pack-enrich", {
-		description: "Run qmd/LLM-assisted enrichment for the active pack. Usage: /memctx-pack-enrich [source-dir]",
+		description: "Run qmd/LLM-assisted enrichment for the active pack in the background. Usage: /memctx-pack-enrich [source-dir]",
 		handler: async (args, ctx) => {
 			if (!activePackPath || !activePack) {
 				ctx.ui.notify("memctx: No active pack to enrich.", "error");
+				return;
+			}
+			if (packEnrichRunning) {
+				ctx.ui.notify("memctx enrich: already running in the background. Wait for completion before starting another enrich.", "warning");
 				return;
 			}
 			let scanDir = (args ?? "").trim();
@@ -3805,18 +3810,25 @@ export default function (pi: ExtensionAPI) {
 				ctx.ui.notify("memctx: Source directory not found. Usage: /memctx-pack-enrich [source-dir]", "error");
 				return;
 			}
+			const pack = activePack;
+			const packPath = activePackPath;
+			const collection = qmdCollection;
 			const started = Date.now();
-			ctx.ui.notify(`memctx enrich: starting for pack ${activePack}\nsource: ${scanDir}\nqmd: ${qmdAvailable ? "available" : "unavailable"}\nllm: ${llmMode}${llmMode === "off" || !ctx.model ? " (architecture synthesis skipped; fact cards still run)" : ""}`, "info");
-			ctx.ui.setStatus("memctx", `📦 ${activePack} · enriching...`);
-			try {
-				const files = await enrichGeneratedPackWithLlm(scanDir, activePack, activePackPath, ctx);
-				if (qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
-				ctx.ui.notify(`memctx enrich: complete in ${Date.now() - started}ms\nupdated files: ${files.length}\n${files.map((f) => `- ${path.relative(activePackPath, f)}`).slice(0, 12).join("\n")}${files.length > 12 ? "\n- ..." : ""}`, "info");
-			} catch (err) {
-				ctx.ui.notify(`memctx enrich: failed after ${Date.now() - started}ms: ${err instanceof Error ? err.message : String(err)}`, "error");
-			} finally {
-				ctx.ui.setStatus("memctx", buildStatusText());
-			}
+			packEnrichRunning = true;
+			ctx.ui.notify(`memctx enrich: started in background for pack ${pack}\nsource: ${scanDir}\nqmd: ${qmdAvailable ? "available" : "unavailable"}\nllm: ${llmMode}${llmMode === "off" || !ctx.model ? " (architecture synthesis skipped; fact cards still run)" : ""}`, "info");
+			ctx.ui.setStatus("memctx", `📦 ${pack} · enriching in background`);
+			void (async () => {
+				try {
+					const files = await enrichGeneratedPackWithLlm(scanDir, pack, packPath, ctx);
+					if (qmdAvailable && collection) qmdEmbed(collection, packPath).catch(() => {});
+					ctx.ui.notify(`memctx enrich: complete in ${Date.now() - started}ms\nupdated files: ${files.length}\n${files.map((f) => `- ${path.relative(packPath, f)}`).slice(0, 12).join("\n")}${files.length > 12 ? "\n- ..." : ""}`, "info");
+				} catch (err) {
+					ctx.ui.notify(`memctx enrich: failed after ${Date.now() - started}ms: ${err instanceof Error ? err.message : String(err)}`, "error");
+				} finally {
+					packEnrichRunning = false;
+					ctx.ui.setStatus("memctx", buildStatusText());
+				}
+			})();
 		},
 	});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- Run `/memctx-pack-enrich` as a guarded background job.
- Keep the Pi terminal responsive while enrichment and qmd indexing continue.
- Prevent concurrent enrich runs with a user-facing warning.
- Bump to v0.8.1.

## Validation
- npm run ci
