### PR TITLE
fix: add v0.8.5 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.8.5] - 2026-05-02
+
+### Fixed
+
+- Remove deprecated transitive install dependency chains so `pi install npm:pi-memctx` no longer emits npm deprecation warnings from bundled dependencies.
+- Resolve `@mariozechner/pi-ai` dynamically from the host Pi installation only when LLM-powered features are used.
+- Keep qmd support optional through `QMD_PATH`, local/vendor binaries, or `PATH`, with grep fallback when qmd is unavailable.
+
+
 ## [0.8.4] - 2026-05-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.8.4-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.8.5-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Add changelog section for v0.8.5.
- Update README release badge to v0.8.5.

## Validation
- metadata-only follow-up after release workflow detected missing changelog section
