### PR TITLE
fix: use recent context for follow-up retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.9.2] - 2026-05-02
+
+### Fixed
+
+- Use recent conversation context for memory retrieval and gateway evaluation so short follow-up prompts can resolve the actual subject from previous turns.
+- Fix the README Pi link to point to `mariozechner/pi-coding-agent`.
+
+
 ## [0.9.1] - 2026-05-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.9.1-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.9.2-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">
@@ -29,7 +29,7 @@
 
 **Stop paying your coding agent to rediscover what your project already knows.**
 
-`pi-memctx` gives [Pi](https://github.com/mariozechner/pi-mono) a local, durable, Markdown-native memory layer. It searches your project memory before each prompt, injects only the context that matters, and lets the agent work normally when memory is not enough.
+`pi-memctx` gives [Pi](https://github.com/mariozechner/pi-coding-agent) a local, durable, Markdown-native memory layer. It searches your project memory before each prompt, injects only the context that matters, and lets the agent work normally when memory is not enough.
 
 No database server. No hosted memory vendor. No new workflow for your users. Just launch Pi and ask the question.
 

--- a/index.ts
+++ b/index.ts
@@ -1151,6 +1151,27 @@ function summarizeGatewayFacts(decision: GatewayJudgeDecision, candidates: Gatew
 	return [...new Set([...modelFacts, ...candidateFacts])].slice(0, broadProject ? 22 : 16);
 }
 
+function promptWithRecentConversation(prompt: string, ctx: ExtensionContext): string {
+	const current = prompt.trim();
+	try {
+		const branch = ctx.sessionManager.getBranch();
+		const recent: string[] = [];
+		for (const entry of branch.slice(-8)) {
+			if (entry.type !== "message") continue;
+			const msg = (entry as any).message;
+			const role = msg?.role;
+			if (role !== "user" && role !== "assistant") continue;
+			const text = messageContentText(msg.content, role === "assistant" ? 900 : 600).replace(/\s+/g, " ").trim();
+			if (!text || text === current) continue;
+			recent.push(`${role}: ${text}`);
+		}
+		if (recent.length === 0) return current;
+		return truncate(["Recent conversation for resolving follow-up prompts:", ...recent.slice(-5), "", `Current prompt: ${current}`].join("\n"), 3500);
+	} catch {
+		return current;
+	}
+}
+
 async function buildMemoryGatewayContext(packPath: string, prompt: string, searchResults: string, retrievalMode: RetrievalStatus["mode"], ctx: ExtensionContext): Promise<string> {
 	const broadProject = isBroadProjectPrompt(prompt);
 	const retrievedCandidates = parseGatewayCandidates(searchResults, retrievalMode);
@@ -3573,8 +3594,9 @@ export default function (pi: ExtensionAPI) {
 		let retrievalBudgetMs = retrievalLatencyBudgetMs;
 		let retrievalTimedOut = false;
 
-		if (event.prompt?.trim()) {
-			const retrieval = await retrieveForPrompt(event.prompt, ctx);
+		const retrievalPrompt = event.prompt?.trim() ? promptWithRecentConversation(event.prompt, ctx) : "";
+		if (retrievalPrompt) {
+			const retrieval = await retrieveForPrompt(retrievalPrompt, ctx);
 			searchResults = retrieval.text;
 			retrievalMode = retrieval.mode;
 			resultCount = retrieval.count;
@@ -3586,9 +3608,10 @@ export default function (pi: ExtensionAPI) {
 			retrievalTimedOut = retrieval.timedOut;
 		}
 
+		const promptForContext = retrievalPrompt || (event.prompt ?? "");
 		const packContext = ["gateway", "qmd-economy"].includes(contextPipeline)
-			? await buildMemoryGatewayContext(activePackPath, event.prompt ?? "", searchResults, retrievalMode, ctx)
-			: buildPackContext(activePackPath, searchResults, event.prompt ?? "");
+			? await buildMemoryGatewayContext(activePackPath, promptForContext, searchResults, retrievalMode, ctx)
+			: buildPackContext(activePackPath, searchResults, promptForContext);
 		if (!packContext) return;
 
 		lastRetrieval = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- Include recent conversation context in memory retrieval/gateway evaluation so short follow-up prompts resolve the actual subject from previous turns.
- Fix README Pi link to point to mariozechner/pi-coding-agent.
- Bump to v0.9.2.

## Validation
- npm run ci
- npm pack includes gateway runtime files
