### PR TITLE
fix: tolerate non-string gateway facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.9.5] - 2026-05-02
+
+### Fixed
+
+- Tolerate non-string fact items returned by the memory gateway judge instead of crashing with `fact.replace is not a function`.
+- Remove private fixture names from generic unit-test coverage and note-targeting stop words.
+
+
 ## [0.9.4] - 2026-05-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.9.4-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.9.5-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/index.ts
+++ b/index.ts
@@ -1182,7 +1182,13 @@ function summarizeGatewayFacts(decision: GatewayJudgeDecision, candidates: Gatew
 		candidateFacts.push(...localFacts.sort((a, b) => a.rank - b.rank).map((fact) => fact.text).slice(0, perCandidateLimit));
 	}
 	const modelFacts = (decision.facts ?? [])
-		.map((fact) => normalizeContextLine(fact.replace(/^[-*#\s]+/, "")))
+		.map((fact) => {
+			const text = typeof fact === "string"
+				? fact
+				: fact == null ? ""
+					: JSON.stringify(fact);
+			return normalizeContextLine(text.replace(/^[-*#\s]+/, ""));
+		})
 		.filter((fact) => fact.length >= 12 && !/^Query:/i.test(fact));
 	return [...new Set([...modelFacts, ...candidateFacts])].slice(0, broadProject ? 22 : 16);
 }
@@ -2303,7 +2309,7 @@ function findSimilarNote(candidate: MemoryCandidate): string | null {
 	if (candidate.type === "session") return null;
 	const exactContext = exactContextTargetNote(candidate);
 	if (exactContext) return exactContext;
-	const stop = new Set(["repo", "repository", "service", "component", "application", "deploy", "deployment", "config", "context", "overview", "korporate"]);
+	const stop = new Set(["repo", "repository", "service", "component", "application", "deploy", "deployment", "config", "context", "overview"]);
 	const terms = candidate.title.toLowerCase().split(/\s+/).filter((term) => term.length > 3 && !stop.has(term)).slice(0, 8);
 	if (terms.length === 0) return null;
 	const dirs = NOTE_TYPE_DIRS[candidate.type].map((dir) => path.join(activePackPath, dir)).filter((dir) => fs.existsSync(dir));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1433,23 +1433,23 @@ describe("memctx_save tool", () => {
 		_setActivePack("test-pack", packPath);
 
 		fs.writeFileSync(path.join(packPath, "20-context", "argo-cd.md"), buildNote("test-pack", "context", "argo-cd", "# argo-cd\n", ["repo/argo-cd"]));
-		fs.writeFileSync(path.join(packPath, "20-context", "poc-grafana-stack.md"), buildNote("test-pack", "context", "poc-grafana-stack", "# poc-grafana-stack\n", ["repo/poc-grafana-stack"]));
+		fs.writeFileSync(path.join(packPath, "20-context", "observability-stack.md"), buildNote("test-pack", "context", "observability-stack", "# observability-stack\n", ["repo/observability-stack"]));
 
 		const result = await tools["memctx_save"].execute(
 			"c1",
 			{
 				type: "context",
-				title: "cards-api-payment deployment in argo-cd",
-				content: "Discovered from `argo-cd/PRD_Argo_Configs/deployments/prd/cards-api-payment/cards-api-payment-v1/values.yaml`.",
-				tags: ["repo/argo-cd", "cards-api-payment"],
+				title: "payments-api deployment in argo-cd",
+				content: "Discovered from `argo-cd/environments/prod/payments-api/values.yaml`.",
+				tags: ["repo/argo-cd", "payments-api"],
 			},
 			null, () => {}, {},
 		);
 
 		expect(result.details.action).toBe("updated");
 		expect(result.details.path).toContain("20-context/argo-cd.md");
-		expect(fs.readFileSync(path.join(packPath, "20-context", "argo-cd.md"), "utf-8")).toContain("cards-api-payment");
-		expect(fs.readFileSync(path.join(packPath, "20-context", "poc-grafana-stack.md"), "utf-8")).not.toContain("cards-api-payment");
+		expect(fs.readFileSync(path.join(packPath, "20-context", "argo-cd.md"), "utf-8")).toContain("payments-api");
+		expect(fs.readFileSync(path.join(packPath, "20-context", "observability-stack.md"), "utf-8")).not.toContain("payments-api");
 	});
 
 	test("blocks AWS keys", async () => {


### PR DESCRIPTION
## Summary
- Tolerate non-string fact items returned by the memory gateway judge instead of crashing with `fact.replace is not a function`.
- Remove private fixture names from generic unit-test coverage and note-targeting stop words.
- Bump to v0.9.5.

## Validation
- npm run ci
- npm pack includes runtime files
- grep check found no private benchmark references in repo files
