### PR TITLE
feat: show all learned memories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.10.1] - 2026-05-02
+
+### Changed
+
+- Show all memories learned from a turn in one post-turn notification/widget instead of only surfacing individual saves.
+- Add same-turn wikilinks between memories learned together so related context, observation, runbook, action, decision, and session notes are easier to navigate and index.
+
+
 ## [0.10.0] - 2026-05-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.10.0-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.10.1-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">

--- a/index.ts
+++ b/index.ts
@@ -2345,6 +2345,38 @@ function findSimilarNote(candidate: MemoryCandidate): string | null {
 	return null;
 }
 
+function memoryWikilink(rel: string, title: string): string {
+	const noExt = rel.replace(/\.md$/, "");
+	return `[[packs/${activePack}/${noExt}|${normalizeContextLine(title)}]]`;
+}
+
+function uniqueSavedMemoryItems<T extends { rel: string }>(items: T[]): T[] {
+	const seen = new Set<string>();
+	return items.filter((item) => {
+		if (seen.has(item.rel)) return false;
+		seen.add(item.rel);
+		return true;
+	});
+}
+
+function appendSameTurnLearnedLinks(items: Array<{ rel: string; title: string; type: NoteType }>): void {
+	if (!activePackPath || !activePack || items.length <= 1) return;
+	items = uniqueSavedMemoryItems(items);
+	if (items.length <= 1) return;
+	const timestamp = nowTimestamp();
+	const links = items
+		.map((item) => `- ${item.type}: ${memoryWikilink(item.rel, item.title)}`)
+		.join("\n");
+	for (const item of items) {
+		const filePath = path.join(activePackPath, item.rel);
+		const existing = readFileSafe(filePath);
+		if (!existing) continue;
+		const marker = `same-turn-${timestamp}`;
+		if (existing.includes(marker)) continue;
+		fs.writeFileSync(filePath, `${existing.trimEnd()}\n\n## Related learned memories <!-- ${marker} -->\n\n${links}\n`, "utf-8");
+	}
+}
+
 function saveMemoryCandidate(candidate: MemoryCandidate): { rel: string; action: "created" | "updated" } {
 	if (!activePackPath || !activePack) throw new Error("No active memory pack");
 	candidate = { ...candidate, title: normalizeNoteTitle(candidate.type, candidate.title), content: sanitizeEvidence(candidate.content) };
@@ -4713,6 +4745,7 @@ export default function (pi: ExtensionAPI) {
 		const maxProcess = (richDiscovery || richSession) ? 12 : 3;
 		let savedCount = 0;
 		let queuedCount = 0;
+		const savedItems: Array<{ rel: string; title: string; type: NoteType; action: "created" | "updated" }> = [];
 		for (const candidate of candidates.slice(0, maxProcess)) {
 			if (sensitivePatternHit(candidate.title, candidate.content)) continue;
 			if (autosaveMode === "auto") {
@@ -4720,7 +4753,7 @@ export default function (pi: ExtensionAPI) {
 					try {
 						const saved = saveMemoryCandidate(candidate);
 						savedCount++;
-						if (ctx.hasUI) ctx.ui.notify(`memctx: learned ${candidate.type}: ${saved.rel}`, "info");
+						savedItems.push({ rel: saved.rel, title: candidate.title, type: candidate.type, action: saved.action });
 					} catch {
 						enqueueMemoryCandidate(candidate);
 						queuedCount++;
@@ -4738,7 +4771,7 @@ export default function (pi: ExtensionAPI) {
 					try {
 						const saved = saveMemoryCandidate(candidate);
 						savedCount++;
-						ctx.ui.notify(`memctx: Saved ${candidate.type}: ${saved.rel}`, "info");
+						savedItems.push({ rel: saved.rel, title: candidate.title, type: candidate.type, action: saved.action });
 						continue;
 					} catch (err) {
 						ctx.ui.notify(`memctx: Could not save candidate: ${err instanceof Error ? err.message : String(err)}`, "error");
@@ -4750,7 +4783,18 @@ export default function (pi: ExtensionAPI) {
 			queuedCount++;
 		}
 
+		appendSameTurnLearnedLinks(savedItems);
 		if ((savedCount > 0 || queuedCount > 0) && qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
+		if (savedItems.length > 0 && ctx.hasUI) {
+			const visibleSavedItems = uniqueSavedMemoryItems(savedItems);
+			const lines = visibleSavedItems.map((item) => `   - ${item.type}: ${memoryWikilink(item.rel, item.title)} (${item.action})`);
+			ctx.ui.notify([`memctx: learned ${visibleSavedItems.length} memor${visibleSavedItems.length === 1 ? "y" : "ies"}:`, ...lines].join("\n"), "info");
+			ctx.ui.setWidget("memctx-learned", [
+				`\x1b[32m🧠 memctx learned ${visibleSavedItems.length} memor${visibleSavedItems.length === 1 ? "y" : "ies"}\x1b[0m`,
+				...lines,
+			]);
+			setTimeout(() => ctx.hasUI && ctx.ui.setWidget("memctx-learned", []), 30000);
+		}
 		if (queuedCount > 0 && ctx.hasUI) {
 			ctx.ui.setWidget("memctx-learn", [
 				`\x1b[33m💡 memctx: ${queuedCount} memory candidate${queuedCount === 1 ? "" : "s"} queued for review.\x1b[0m`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- Aggregate post-turn learned memories into one notification/widget that lists every saved note.
- Include Obsidian-style wikilinks for each learned note.
- Add same-turn wikilink sections to learned notes so related memories are easier to navigate and index/search.
- Bump to v0.10.1.

## Validation
- npm run ci
- npm pack includes runtime files
