### PR TITLE
feat: simplify workspace memory UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.11.0] - 2026-05-03
+
+### Changed
+
+- Shift the public UX from user-managed packs to workspace memory: `/memctx-init`, `/memctx-status`, `/memctx-refresh`, `/memctx-doctor`, and `/memctx` are now the simplified command surface.
+- Remove noisy pack/profile/retrieval/autosave commands from the public command surface. Internal Markdown packs still back workspace memory.
+- Add workspace path mapping so initialized workspace memory can be resolved automatically from the current directory and subdirectories.
+- Simplify the status overlay wording to focus on memory readiness, hits, search backend, and learning status.
+- Update README and docs around workspace memory, simplified commands, and advanced environment-based configuration.
+
+
 ## [0.10.2] - 2026-05-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/weauratech/pi-memctx/stargazers"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fweauratech%2Fpi-memctx&query=%24.stargazers_count&label=stars&color=yellow&style=flat&logo=github" alt="Stars"></a>
   <a href="https://github.com/weauratech/pi-memctx/commits/main"><img src="https://img.shields.io/github/last-commit/weauratech/pi-memctx?style=flat" alt="Last Commit"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/weauratech/pi-memctx?style=flat" alt="License"></a>
-  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.10.2-blue?style=flat" alt="Latest Release"></a>
+  <a href="https://github.com/weauratech/pi-memctx/releases/latest"><img src="https://img.shields.io/badge/release-v0.11.0-blue?style=flat" alt="Latest Release"></a>
 </p>
 
 <p align="center">
@@ -21,7 +21,7 @@
   <a href="#automatic-learning">Learning</a> •
   <a href="#benchmark">Benchmark</a> •
   <a href="#how-it-works">How it works</a> •
-  <a href="#memory-packs">Packs</a> •
+  <a href="#workspace-memory">Workspace memory</a> •
   <a href="#commands">Commands</a> •
   <a href="#development">Development</a>
 </p>
@@ -72,10 +72,10 @@ pi -e pi-memctx
 Inside Pi:
 
 ```txt
-/memctx-pack-generate
+/memctx-init
 ```
 
-`pi-memctx` scans the workspace and creates a structured Markdown memory pack with context, decisions, runbooks, and indexes.
+`pi-memctx` scans the workspace and creates local Markdown workspace memory with context, decisions, runbooks, and indexes. Internally this is stored as a pack, but most users do not need to manage packs directly.
 
 ### 4. Ask normally
 
@@ -206,18 +206,11 @@ The gateway does **not** replace the main LLM. It does the boring part first: fi
 |---|---|---|
 | `gateway` | Fast daily use | Conservative local judge, compact context, qmd/grep retrieval, zero redundant memory searches when memory is sufficient. |
 
-Inspect or re-apply the profile inside Pi:
+The profile is applied by default. Use `/memctx-status --advanced` if you need to inspect the active runtime settings. Old profile names such as `gateway-lite`, `gateway-full`, `qmd-economy`, `low`, `balanced`, `auto`, and `full` are compatibility-mapped to `gateway` in configuration files.
 
-```txt
-/memctx-profile status
-/memctx-profile gateway
-```
+## Workspace memory
 
-Old profile names such as `gateway-lite`, `gateway-full`, `qmd-economy`, `low`, `balanced`, `auto`, and `full` are compatibility-mapped to `gateway`.
-
-## Memory packs
-
-A pack is a directory of Markdown files with frontmatter. You can edit it with any editor, commit it, review it, or open it in Obsidian.
+Each workspace gets local Markdown memory. Internally, workspace memory is stored as a pack directory with frontmatter. You can edit it with any editor, commit it, review it, or open it in Obsidian.
 
 ```txt
 packs/my-project/
@@ -264,26 +257,13 @@ Most users only need the daily commands:
 
 | Command | Purpose |
 |---|---|
-| `/memctx-pack-generate` | Create a memory pack from the current workspace. If a model is selected, deep LLM enrichment starts in the background by default; use `--no-deep` to skip it. |
-| `/memctx-pack` | Select or show the active pack. |
-| `/memctx-profile gateway` | Re-apply the recommended profile. |
-| `/memctx-doctor` | Diagnose qmd, packs, and configuration. |
+| `/memctx` | Show compact help and current memory status. |
+| `/memctx-init` | Create/update memory for this workspace. If a model is selected, deep LLM enrichment starts in the background by default; use `--no-deep` to skip it. |
+| `/memctx-status` | Show workspace memory status; add `--advanced` for internal paths/config. |
+| `/memctx-refresh` | Refresh workspace memory inventory/enrichment in the background. |
+| `/memctx-doctor` | Diagnose qmd, workspace memory, and configuration. |
 
-<details>
-<summary>Advanced commands</summary>
-
-| Command | Purpose |
-|---|---|
-| `/memctx-pack-status` | Show active pack and retrieval status. |
-| `/memctx-config` | Show current config. |
-| `/memctx-retrieval` | Configure retrieval policy. |
-| `/memctx-autosave` | Configure automatic learning behavior. The default gateway profile uses conservative `auto`. |
-| `/memctx-save-queue` | Review queued lower-confidence memory candidates. |
-| `/memctx-pack-enrich` | Enrich a pack with deterministic repository inventory and optional LLM synthesis. Runs in the background. |
-
-Deprecated aliases such as `/pack` and `/pack-generate` are still registered for compatibility.
-
-</details>
+Older pack/config commands were removed from the public command surface to keep the extension simple. Advanced behavior is still configurable through environment variables and the local config file.
 
 ## Tools
 
@@ -329,7 +309,7 @@ Secret-looking content is blocked.
 `pi-memctx` keeps a small status overlay in Pi:
 
 ```txt
-🧠 my-pack · memory ready · 3 memory hits · search:qmd · profile:gateway · learn auto
+🧠 my-pack · memory ready · 3 memory hits · qmd · learn auto
 ```
 
 This tells you which pack is active, whether memory was useful, which search backend is being used, and whether automatic learning is enabled.
@@ -397,7 +377,7 @@ Memory is Markdown on disk. You can inspect every byte.
 
 ## Configuration
 
-Most users should start with the defaults. Advanced users can configure behavior with environment variables or `/memctx-profile`.
+Most users should start with the defaults. Advanced users can configure behavior with environment variables or the local config file at `~/.config/pi-memctx/config.json`.
 
 Common environment variables:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,21 +7,18 @@ pi-memctx is a single Pi extension implemented in `index.ts`.
 ```txt
 session_start
   -> load persistent profile/config from ~/.config/pi-memctx/config.json
-  -> resolve pack directory
-  -> ask before bootstrapping a pack when no pack is found
-  -> detect active pack
-  -> resolve qmd from MEMCTX_QMD_BIN, PATH, or bundled optional dependency
+  -> resolve workspace memory from workspace-map.json by longest cwd prefix
+  -> resolve pack directory and active internal Markdown pack
+  -> resolve qmd from explicit env/local/PATH or use grep fallback
   -> optionally index with qmd
 
 before_agent_start
-  -> optionally switch packs from prompt intent
+  -> optionally switch memory from cwd/prompt intent
   -> apply retrieval policy (auto/fast/balanced/deep/strict)
-  -> keep auto retrieval latency-bounded (default 1000ms)
-  -> optionally expand queries with LLM
-  -> search active pack for prompt-relevant context with qmd when available
-  -> fall back to grep-style Markdown search when qmd is unavailable or returns no result
-  -> build bounded context block
-  -> append context plus Memory Gate guidance to the system prompt
+  -> keep auto retrieval latency-bounded
+  -> search active workspace memory for prompt-relevant context
+  -> build compact Memory Gateway Brief
+  -> append context and guidance to the system prompt
 
 memctx_search
   -> qmd keyword/semantic/deep search when available
@@ -29,11 +26,15 @@ memctx_search
 
 memctx_save
   -> validate content against secret patterns
+  -> normalize note titles
   -> write Markdown note with frontmatter
-  -> update an index when available
+  -> update/index related links when appropriate
 
 agent_end
-  -> optionally generate/queue autosave memory candidates
+  -> curate durable memory candidates
+  -> enrich shallow candidates from detailed final answers
+  -> save linked context/observation/runbook/decision/action/session notes
+  -> force sanitized rich-persistence session snapshots for large detailed turns
 
 session_before_compact
   -> write a compact handoff action note, LLM-structured when available
@@ -41,19 +42,36 @@ session_before_compact
 tool_result
   -> on tool failures, search memory for potentially relevant troubleshooting notes
 
-memctx-pack-generate
-  -> discover repositories under the target directory
+/memctx-init
+  -> discover repositories under the target workspace
   -> collect sanitized evidence from docs, manifests, workflows, git, and safe command sources
-  -> write full pack structure, resource map, context notes, project notes, observations, runbooks, and indexes
+  -> write full internal pack structure, resource map, context notes, project notes, observations, runbooks, and indexes
+  -> record workspace path -> memory mapping
+
+/memctx-refresh
+  -> rerun deterministic inventory and optional LLM synthesis in the background
 ```
+
+## User-facing model
+
+The public UX is **workspace memory**:
+
+- `/memctx` — compact help and current status
+- `/memctx-init` — create/update memory for the current workspace
+- `/memctx-status` — show workspace memory status (`--advanced` reveals internal paths/config)
+- `/memctx-refresh` — refresh workspace inventory/enrichment
+- `/memctx-doctor` — diagnose setup issues
+
+The internal storage model remains Markdown packs under a memory vault. Packs are useful for isolation, indexing, links, and versioning, but ordinary users should not need to switch or manage them manually.
 
 ## Design principles
 
 - Local-first: no hosted service is required.
 - Markdown-first: memory is reviewable with normal tools.
+- Workspace-first UX: users initialize memory for a directory and then ask normally.
 - Bounded context: lower-priority sections are trimmed before flooding the prompt.
 - qmd optional: semantic search is attempted automatically when available, but grep fallback remains the hard guarantee.
-- Observable memory state: `/memctx-pack-status` reports active pack, profile/config, qmd resolution, LLM mode, strict mode, retrieval policy, autosave mode, and last retrieval; the footer overlay includes current profile, `memctx-strict`, `memctx-llm`, retrieval, and autosave values.
-- Strict guidance defaults to on. Disable with `MEMCTX_STRICT=false` or `/memctx-strict off` when lower retrieval pressure is preferred.
+- Observable memory state: `/memctx-status` reports workspace memory readiness; `/memctx-status --advanced` shows internal pack/config/search details.
+- Rich persistence by default: when pi-memctx persists, notes should be reusable without the original conversation.
 - Source of truth wins: repository files and live system state override memory notes.
-- Generated memory is conservative: deterministic pack generation avoids destructive commands and redacts sensitive-looking values.
+- Generated memory is conservative: deterministic generation avoids destructive commands and redacts sensitive-looking values.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,14 @@
 # Getting Started
 
-pi-memctx is a Pi extension that loads local Markdown memory packs, injects relevant context before the agent acts, and exposes tools for search and safe persistence.
+pi-memctx is a Pi extension that gives each workspace local Markdown memory. It injects relevant context before the agent acts and can learn durable discoveries after turns.
 
 ## Install
+
+```bash
+pi install npm:pi-memctx
+```
+
+Or install from GitHub:
 
 ```bash
 pi install git:github.com/weauratech/pi-memctx
@@ -10,25 +16,46 @@ pi install git:github.com/weauratech/pi-memctx
 
 Restart Pi or run `/reload` if your Pi session supports it.
 
-## Pack locations
+## Initialize workspace memory
 
-pi-memctx looks for packs in this order:
+Start Pi from your project/workspace:
+
+```bash
+cd /path/to/workspace
+pi -e pi-memctx
+```
+
+Inside Pi:
+
+```txt
+/memctx-init
+```
+
+`/memctx-init` creates or updates local Markdown memory for the current workspace, writes a workspace-to-memory mapping, and starts background enrichment when a model is selected. Internally the memory is stored as a Markdown pack, but most users do not need to switch or manage packs manually.
+
+## Daily commands
+
+```txt
+/memctx          # compact help and current status
+/memctx-init     # create/update memory for this workspace
+/memctx-status   # show workspace memory status
+/memctx-refresh  # refresh inventory/enrichment in the background
+/memctx-doctor   # diagnose setup issues
+```
+
+Add `--advanced` to `/memctx-status` when you need internal paths/config details.
+
+## Where memory lives
+
+pi-memctx stores workspace memory under a local memory vault. It resolves packs in this order:
 
 1. `MEMCTX_PACKS_PATH`
 2. `<cwd>/.pi/memory-vault/packs/`
 3. `~/.pi/agent/memory-vault/packs/`
 
-## Create a pack
+Workspace path mappings are stored in the vault under `00-system/workspace-map.json`, so subdirectories can resolve the same workspace memory automatically.
 
-Use `/memctx-pack-generate` inside a Pi session:
-
-```txt
-/memctx-pack-generate /path/to/repos my-project
-```
-
-The generator performs deterministic local discovery of repositories, read-first docs, package scripts, GitHub Actions, Git remotes, Go/Node manifests, safe development commands, and selected infrastructure hints. When `MEMCTX_LLM_MODE` is enabled and a model is selected, it also performs LLM-assisted deep enrichment from selected redacted source snippets. See [Pack generation](pack-generate.md).
-
-Or create folders manually:
+Example internal structure:
 
 ```txt
 packs/my-project/
@@ -43,33 +70,35 @@ packs/my-project/
 
 See `examples/basic-pack/` for a minimal public-safe pack.
 
-## Use a pack
+## Use memory naturally
+
+Ask normal questions:
 
 ```txt
-/memctx-pack
-/memctx-pack my-project
-/memctx-pack-status
+How do I deploy this service to production?
 ```
 
-Deprecated aliases remain available for compatibility: `/pack`, `/pack-status`, and `/pack-generate`.
+pi-memctx retrieves prompt-relevant memory automatically before each turn. It uses qmd when available and grep fallback otherwise. If memory is insufficient or stale, Pi inspects the repository normally.
 
-pi-memctx starts with `profile:gateway` and persists config in `~/.config/pi-memctx/config.json`. Use `/memctx-profile gateway` to re-apply the default Memory Gateway profile, or `/memctx-config reset` to return to defaults.
+The gateway profile enables conservative automatic learning by default. After detailed turns, pi-memctx may save linked context, observations, runbooks, actions, decisions, and rich session snapshots as Markdown.
 
-Strict mode is off by default because the gateway first injects compact memory and only asks the agent to inspect source files when memory is insufficient, stale, or conflicting. You can toggle it when needed:
+## Search or save explicitly
+
+Ask the agent to search memory:
 
 ```txt
-/memctx-strict on
-/memctx-strict off
+Use memctx_search to find the deploy runbook.
 ```
 
-Advanced commands can override the active profile and mark it `custom`:
+Ask the agent to save durable memory:
 
 ```txt
-/memctx-auto-switch all
-/memctx-llm assist
+Save this as a decision: we use deterministic e2e packs for integration tests.
 ```
 
-Environment equivalents:
+## Advanced configuration
+
+Most users should keep defaults. Advanced behavior can be controlled with environment variables or `~/.config/pi-memctx/config.json`:
 
 ```bash
 MEMCTX_AUTO_SWITCH=off|cwd|prompt|all
@@ -78,24 +107,4 @@ MEMCTX_RETRIEVAL=auto|fast|balanced|deep|strict
 MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS=1000
 MEMCTX_AUTOSAVE=off|suggest|confirm|auto
 MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE=true
-```
-
-The gateway profile enables conservative automatic learning by default. Use `/memctx-doctor` when you need diagnostics:
-
-```txt
-/memctx-doctor
-```
-
-Ask the agent to search memory:
-
-```txt
-Use memctx_search to find the deploy runbook.
-```
-
-pi-memctx also retrieves prompt-relevant memory automatically before each turn. It uses qmd when available and grep fallback otherwise.
-
-Ask the agent to save durable memory:
-
-```txt
-Save this as a decision: we use deterministic e2e packs for integration tests.
 ```

--- a/docs/pack-generate.md
+++ b/docs/pack-generate.md
@@ -1,96 +1,61 @@
-# Pack generation
+# Workspace memory initialization
 
-`/memctx-pack-generate` creates a memory pack from a directory of repositories.
-
-```txt
-/memctx-pack-generate /path/to/repos my-project
-```
-
-`/pack-generate` remains available as a deprecated compatibility alias.
-
-If no path is provided, pi-memctx scans the current working directory. If no slug is provided, it derives one from the scanned directory name.
-
-## Hybrid discovery and LLM enrichment
-
-The generator first performs deterministic local discovery so pack structure is always created even when no model is available. When `MEMCTX_LLM_MODE` is `assist` or `first` and a Pi model is selected, `/memctx-pack-generate` then runs token-conscious LLM enrichment.
-
-The local deterministic pass detects:
-
-- normal top-level repositories;
-- hidden repository allowlist entries such as `.github` and `.gitlab`;
-- Git remotes and current branch when available;
-- Node/TypeScript projects from `package.json` and lockfiles;
-- Go projects from `go.mod`;
-- infrastructure/config hints such as Docker, Terraform, Helm, Kubernetes, `infra/`, and CI workflows;
-- read-first docs such as `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, and selected `docs/**/*.md` files;
-- safe development commands from package scripts, Go manifests, and Make targets.
-
-## LLM-assisted deep enrichment
-
-When LLM enrichment is enabled, pi-memctx:
-
-1. builds a compact file inventory per active repository;
-2. asks the selected model to choose the highest-value files for architecture/API/data-model/integration understanding;
-3. extracts redacted snippets only from those selected files;
-4. asks the model to synthesize compact JSON;
-5. writes evidence-based architecture notes such as `20-context/<repo>-llm-architecture.md`;
-6. appends those notes to `00-system/indexes/context-index.md`.
-
-Token controls:
-
-- file inventory is metadata-first;
-- selected files are capped;
-- snippets are truncated;
-- sensitive filenames are skipped;
-- high-confidence secret-looking values are redacted before model use.
-
-Disable LLM use with:
-
-```bash
-MEMCTX_LLM_MODE=off
-```
-
-Prefer stronger LLM usage with:
-
-```bash
-MEMCTX_LLM_MODE=first
-```
-
-## Generated structure
-
-The generated pack uses the full memory-pack layout:
+`/memctx-init` creates or updates local Markdown memory for the current workspace.
 
 ```txt
-00-system/pi-agent/memory-manifest.md
-00-system/pi-agent/retrieval-protocol.md
-00-system/pi-agent/resource-map.md
-00-system/indexes/*.md
-10-user/
-20-context/overview.md
-20-context/<repo>.md
-20-context/<repo>-llm-architecture.md   # when LLM enrichment runs
-30-projects/<repo>.md
-40-actions/
-50-decisions/
-60-observations/workspace-repository-map.md
-70-runbooks/<repo>-development.md
-80-sessions/
+/memctx-init
+/memctx-init /path/to/repos my-project
+/memctx-init --no-deep
 ```
 
-Runbooks are generated only when safe setup/check commands are inferred. Deploy, production, release, publish, destructive, and credential-related commands are excluded from generated runbooks.
+The command performs deterministic local discovery so memory structure is always created even when no model is available. When a Pi model is selected, deep LLM enrichment starts in the background by default. Use `--no-deep` to skip LLM enrichment.
 
-## Safety and redaction
+Internally, workspace memory is stored as a Markdown pack. Most users do not need to manage packs directly.
 
-The generator skips sensitive file names such as `.env`, private keys, credential files, and secret files. It also redacts high-confidence secret-looking values before writing notes.
+## What gets generated
 
-Generated notes are context, not authority. Source-of-truth repository files, tests, CI, and live runtime facts override memory.
+`/memctx-init` creates a pack with:
 
-## Enriching an existing pack
+- `00-system/pi-agent/memory-manifest.md`
+- `00-system/pi-agent/resource-map.md`
+- `00-system/indexes/*.md`
+- `20-context/<repo>.md`
+- `30-projects/<repo>.md`
+- `60-observations/workspace-repository-map.md`
+- optional `70-runbooks/*` for safe generated development notes
 
-Use `/memctx-pack-enrich [source-dir]` to rerun deterministic repository inventory and optional LLM-assisted enrichment for the active pack without regenerating the entire pack. The command runs in the background so the Pi terminal remains responsive. If `source-dir` is omitted, pi-memctx tries the source directory recorded in the pack resource map.
+It also records the workspace path in `00-system/workspace-map.json` so future sessions inside that workspace or subdirectories can resolve the correct memory automatically.
 
-When a model is selected, `/memctx-pack-generate` starts LLM-assisted deep enrichment in the background by default after writing the deterministic pack. Use `/memctx-pack-generate --no-deep` to skip LLM enrichment. Generation always writes deterministic repository context, source inventory, stack signals, and safe source-of-truth pointers first.
+## Refreshing memory
 
-## Current limitations
+Use `/memctx-refresh` to rerun deterministic repository inventory and optional LLM-assisted enrichment for the active workspace memory without rebuilding everything:
 
-LLM enrichment is intentionally evidence-bounded: it summarizes selected redacted snippets and should not be treated as source of truth. If no model is selected or no API key is available, `/memctx-pack-generate` still produces the deterministic pack and skips LLM enrichment with a warning.
+```txt
+/memctx-refresh
+/memctx-refresh /path/to/repos
+/memctx-refresh --no-deep
+```
+
+The refresh runs in the background so the Pi terminal remains responsive.
+
+## Discovery behavior
+
+The generator looks for source-of-truth signals such as:
+
+- Git remotes and current branch
+- README/AGENTS/CLAUDE docs
+- package scripts and safe development commands
+- GitHub Actions workflows
+- Go/Node/Java/Python/Terraform/Kubernetes/YAML/SQL files
+- repository directory structure
+- selected source inventory and redacted excerpts
+
+Large files, hidden directories, dependency folders, and sensitive file names are skipped.
+
+## LLM enrichment
+
+When a model is selected, pi-memctx asks the model to synthesize compact architecture notes from selected redacted evidence. LLM-generated notes are context, not source of truth. Repository files still win when behavior matters.
+
+## Safety
+
+Generated content is sanitized before being written. Do not store secrets, credentials, tokens, customer data, or sensitive payloads in memory packs.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,33 +1,64 @@
-# Persistence
+# Persistence and automatic learning
 
-`memctx_save` writes durable notes to the active pack. The gateway profile also runs a conservative post-turn memory curator by default: after each meaningful turn, pi-memctx looks for durable project knowledge, conventions, runbooks, architecture, business rules, completed actions, or explicit user/team preferences worth saving.
+pi-memctx can learn durable project knowledge after a turn and save it as local Markdown.
 
-## Supported types
+The default `gateway` profile uses conservative automatic learning. When a completed turn contains useful durable knowledge, pi-memctx may save linked notes such as:
 
-- `observation`: discovered fact about code, infra, behavior, or conventions.
-- `decision`: durable technical or architectural decision with rationale.
-- `action`: completed task or notable change.
-- `runbook`: repeatable procedure.
-- `context`: project, stack, or team context.
+- `20-context/` — workspace/repository/component context
+- `40-actions/` — completed work or delivered plans
+- `50-decisions/` — technical decisions with rationale
+- `60-observations/` — durable facts, requirements, caveats, patterns
+- `70-runbooks/` — repeatable procedures
+- `80-sessions/` — sanitized rich planning/discovery snapshots
 
-## Behavior
+## Rich persistence
 
-- Notes are Markdown files with frontmatter.
-- Existing notes with the same slug are appended to instead of overwritten.
-- Action notes include the current date in the filename.
-- Index files are updated when a matching index exists.
-- Common secret patterns are blocked before writing.
-- High-confidence curator candidates are saved automatically in `auto` mode; lower-confidence candidates are queued locally for review.
+When the final answer contains detailed planning, debugging, implementation, or repository-discovery content, pi-memctx enriches saved notes so future agents can reuse them without the original conversation. It also forces an `80-sessions` snapshot for large detailed turns when durable memory is saved.
 
-## Autosave and review
+Example post-turn UI:
 
 ```txt
-/memctx-autosave off|suggest|confirm|auto|status
-/memctx-save-queue list|approve <id>|reject <id>|clear
+memctx: learned 5 memories:
+   - context: [[packs/my-pack/20-context/payment-api|Payment API]] (updated)
+   - observation: [[packs/my-pack/60-observations/deploy-patterns|Deploy patterns]] (created)
+   - runbook: [[packs/my-pack/70-runbooks/deploy-payment-api|Deploy Payment API]] (created)
+   - action: [[packs/my-pack/40-actions/2026-05-02-prepared-rollout|Prepared rollout]] (created)
+   - session: [[packs/my-pack/80-sessions/rich-persistence-payment-api|Rich planning snapshot]] (created)
 ```
 
-`autosave=suggest` queues candidates and shows a widget. `autosave=confirm` asks immediately. `autosave=auto` writes directly when confidence is high and queues lower-confidence candidates when `MEMCTX_AUTOSAVE_QUEUE_LOW_CONFIDENCE=true` (the gateway default).
+Learned notes are cross-linked with `[[wikilinks]]` to improve navigation and future retrieval.
 
-## Limitations
+## Explicit saves
 
-Secret detection is defensive, not perfect. Review memory notes before publishing or sharing packs.
+The `memctx_save` tool remains available to the agent when you explicitly ask it to remember something:
+
+```txt
+Save this as a runbook: production deploy requires the release checklist and manual approval.
+```
+
+Supported note types:
+
+- `context`
+- `observation`
+- `runbook`
+- `decision`
+- `action`
+- `session`
+
+## Safety
+
+pi-memctx blocks or redacts secret-looking content before persistence. Do not ask it to save:
+
+- API keys
+- tokens
+- passwords
+- private keys
+- credentials
+- customer data
+- sensitive payloads
+
+If a secret-like value appeared in a turn, pi-memctx should summarize the risk without storing the value.
+
+## Advanced configuration
+
+Most users should keep the default learning mode. Advanced users can set `MEMCTX_AUTOSAVE=off|suggest|confirm|auto` or edit `~/.config/pi-memctx/config.json`.

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,44 +1,58 @@
-# Search
+# Search and retrieval
 
-`memctx_search` searches the active memory pack. Automatic context injection also performs prompt-specific retrieval before each agent turn using the configured retrieval policy.
-
-## Tool modes
-
-- `keyword`: fast default mode.
-- `semantic`: meaning-based search when qmd is installed.
-- `deep`: hybrid/reranked search when qmd is installed.
-
-## Automatic retrieval policies
+pi-memctx retrieves relevant workspace memory automatically before each prompt. The main user workflow is simply:
 
 ```txt
-/memctx-retrieval auto|fast|balanced|deep|strict|status
+Ask Pi normally.
 ```
 
-- `auto`: default; starts with fast keyword retrieval and only attempts bounded expansion when needed.
-- `fast`: one keyword query.
-- `balanced`: keyword plus LLM-expanded queries when available.
-- `deep`: multi-query retrieval with deeper qmd mode.
-- `strict`: always attempts expanded retrieval and reports attempted queries/cross-pack hints.
+The Memory Gateway searches local Markdown notes, judges whether they are useful, injects compact context when appropriate, and lets Pi inspect the repository normally when memory is insufficient or stale.
 
-`auto` uses `MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS` with a default of `1000`, so strict mode no longer turns `auto` into full strict retrieval. Use `/memctx-retrieval strict` when depth matters more than latency.
+## Search backend
 
-qmd is resolved from `QMD_PATH`/`MEMCTX_QMD_BIN`, already-installed local/vendor binaries, or `PATH`. Without qmd, pi-memctx falls back to local grep-style Markdown search. qmd is no longer installed automatically with pi-memctx so `pi install npm:pi-memctx` stays small and warning-free.
+pi-memctx uses qmd when available and falls back to grep when qmd is missing.
 
-## Examples
-
-```txt
-memctx_search(query="deploy rollback", mode="keyword", limit=5)
-memctx_search(query="why did we choose postgres", mode="semantic", limit=5)
-memctx_search(query="incident runbook for queue lag", mode="deep", limit=3)
-```
-
-## qmd
-
-pi-memctx attempts to use qmd automatically:
+Resolution order:
 
 1. `QMD_PATH` or `MEMCTX_QMD_BIN`
-2. local `node_modules/.bin/qmd` or `vendor/qmd/<platform>-<arch>/qmd`
+2. local/vendor binary paths
 3. `qmd` on `PATH`
 4. grep fallback
 
-Use `/memctx-pack-status`, `/memctx-doctor`, or `npx pi-memctx doctor` to see which path is active. `/pack-status` remains available as a deprecated compatibility alias.
+Check setup with:
+
+```txt
+/memctx-doctor
+```
+
+or:
+
+```bash
+npx pi-memctx doctor
+```
+
+## Explicit search
+
+The `memctx_search` tool is available to the agent. You can ask for it explicitly:
+
+```txt
+Use memctx_search to find the deploy runbook.
+```
+
+Modes:
+
+- `keyword` — fast lexical search
+- `semantic` — meaning-based qmd search when available
+- `deep` — hybrid/reranked qmd search when available
+
+When the Memory Gateway already injected sufficient memory, the agent is instructed not to call `memctx_search` again. That keeps answers fast and avoids duplicate retrieval.
+
+## Tuning
+
+Most users should keep the default `gateway` profile. Advanced users can tune retrieval with environment variables or `~/.config/pi-memctx/config.json`:
+
+```bash
+MEMCTX_RETRIEVAL=auto|fast|balanced|deep|strict
+MEMCTX_RETRIEVAL_LATENCY_BUDGET_MS=1000
+MEMCTX_GATEWAY_JUDGE=off|conservative|auto|main-llm
+```

--- a/index.ts
+++ b/index.ts
@@ -108,6 +108,16 @@ type PackSwitch = {
 	timestamp: string;
 };
 
+type WorkspaceMap = {
+	version: 1;
+	workspaces: Array<{
+		path: string;
+		pack: string;
+		createdAt: string;
+		lastUsedAt: string;
+	}>;
+};
+
 type LlmStats = {
 	mode: LlmMode;
 	callsThisSession: number;
@@ -559,15 +569,80 @@ export function detectBestPackForCwd(packsDir: string, cwd: string): PackMatch |
 	return matches[0]?.score ? matches[0] : null;
 }
 
+function workspaceMapPathForPacksDir(packsDir: string): string {
+	return path.join(path.dirname(packsDir), "00-system", "workspace-map.json");
+}
+
+function loadWorkspaceMap(packsDir: string): WorkspaceMap {
+	const raw = readFileSafe(workspaceMapPathForPacksDir(packsDir));
+	if (!raw) return { version: 1, workspaces: [] };
+	try {
+		const parsed = JSON.parse(raw) as WorkspaceMap;
+		return { version: 1, workspaces: Array.isArray(parsed.workspaces) ? parsed.workspaces : [] };
+	} catch {
+		return { version: 1, workspaces: [] };
+	}
+}
+
+function saveWorkspaceMap(packsDir: string, map: WorkspaceMap): void {
+	const file = workspaceMapPathForPacksDir(packsDir);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, JSON.stringify({ version: 1, workspaces: map.workspaces }, null, 2) + "\n", "utf-8");
+}
+
+function rememberWorkspaceMemory(packsDir: string, workspacePath: string, pack: string): void {
+	const resolved = path.resolve(workspacePath);
+	const now = nowTimestamp();
+	const map = loadWorkspaceMap(packsDir);
+	const existing = map.workspaces.find((item) => path.resolve(item.path) === resolved);
+	if (existing) {
+		existing.pack = pack;
+		existing.lastUsedAt = now;
+	} else {
+		map.workspaces.push({ path: resolved, pack, createdAt: now, lastUsedAt: now });
+	}
+	map.workspaces.sort((a, b) => b.path.length - a.path.length || a.path.localeCompare(b.path));
+	saveWorkspaceMap(packsDir, map);
+}
+
+function detectWorkspacePackForCwd(packsDir: string, cwd: string): PackMatch | null {
+	const cwdResolved = path.resolve(cwd);
+	const packs = new Set(listPacks(packsDir));
+	for (const item of loadWorkspaceMap(packsDir).workspaces.sort((a, b) => b.path.length - a.path.length)) {
+		const workspacePath = path.resolve(item.path);
+		if (!packs.has(item.pack)) continue;
+		if (cwdResolved === workspacePath || cwdResolved.startsWith(`${workspacePath}${path.sep}`)) {
+			return {
+				pack: item.pack,
+				packPath: path.join(packsDir, item.pack),
+				score: 120,
+				confidence: "high",
+				reasons: [`cwd matched workspace memory ${workspacePath}`],
+			};
+		}
+	}
+	return null;
+}
+
 export function detectActivePack(packsDir: string, cwd?: string): string | null {
 	const packs = listPacks(packsDir);
 	if (packs.length === 0) return null;
+
+	if (cwd) {
+		const workspaceMatch = detectWorkspacePackForCwd(packsDir, cwd);
+		if (workspaceMatch) {
+			lastPackSelection = workspaceMatch;
+			rememberWorkspaceMemory(packsDir, cwd, workspaceMatch.pack);
+			return workspaceMatch.pack;
+		}
+	}
 	if (packs.length === 1) return packs[0];
 
 	if (cwd) {
 		const match = detectBestPackForCwd(packsDir, cwd);
 		if (match) {
 			lastPackSelection = match;
+			rememberWorkspaceMemory(packsDir, cwd, match.pack);
 			return match.pack;
 		}
 	}
@@ -1358,9 +1433,9 @@ function buildStatusText(): string {
 		? lastRetrieval.timedOut ? `search timeout (${lastRetrieval.resultCount})`
 			: `${lastRetrieval.resultCount} memory hit${lastRetrieval.resultCount === 1 ? "" : "s"}`
 		: "idle";
-	const search = qmdStatus.available ? "qmd" : "grep fallback";
+	const search = qmdStatus.available ? "qmd" : "grep";
 	const save = autosaveMode === "off" ? "learn off" : autosaveMode === "auto" ? "learn auto" : `learn ${autosaveMode}`;
-	return `🧠 ${activePack || "no pack"} · ${gateway} · ${memory} · search:${search} · profile:gateway · ${save}`;
+	return `🧠 ${activePack || "no memory"} · ${gateway} · ${memory} · ${search} · ${save}`;
 }
 
 function isNoResultText(text: string): boolean {
@@ -1870,7 +1945,7 @@ incomplete: no project-specific facts generated yet
 
 ## Sources
 
-- Run /memctx-pack-enrich to synthesize this card from local memory evidence.
+- Run /memctx-refresh to synthesize this card from local memory evidence.
 `;
 }
 
@@ -3705,11 +3780,11 @@ async function maybeBootstrapPack(ctx: ExtensionContext, packsDir: string): Prom
 		ctx.cwd,
 		"",
 		`Create and map a new pack named \"${slug}\" now?`,
-		"Choose No if you prefer to run /memctx-pack-generate later.",
+		"Choose No if you prefer to run /memctx-init later.",
 	].join("\n");
 	const confirmed = autoBootstrapMode === "on" ? await ctx.ui.confirm("Create memory pack?", message) : await ctx.ui.confirm("Create memory pack?", message);
 	if (!confirmed) {
-		ctx.ui.notify("memctx: Pack bootstrap skipped. Run /memctx-pack-generate when you want to create one.", "info");
+		ctx.ui.notify("memctx: Workspace memory setup skipped. Run /memctx-init when you want to create it.", "info");
 		return false;
 	}
 	fs.mkdirSync(packsDir, { recursive: true });
@@ -3780,7 +3855,7 @@ export default function (pi: ExtensionAPI) {
 			} else {
 				if (ctx.hasUI) {
 					ctx.ui.notify(
-						"memctx: No packs found. Run /memctx-pack-generate to create one, or set MEMCTX_PACKS_PATH.",
+						"memctx: No workspace memory found. Run /memctx-init to create one, or set MEMCTX_PACKS_PATH.",
 						"info",
 					);
 				}
@@ -3996,275 +4071,174 @@ export default function (pi: ExtensionAPI) {
 		// Nothing to flush at the moment
 	});
 
-	// --- /memctx-pack-status command: show active pack and retrieval state ---
-	const packStatusCommand = {
-		description: "Show active memory pack, qmd, retrieval, strict-mode, and LLM status. Usage: /memctx-pack-status",
-		handler: async (_args: string, ctx: ExtensionContext) => {
-			const packsDir = _packsDir || (vaultRoot ? path.join(vaultRoot, "packs") : "");
-			const packFileCount = activePackPath ? scanPackFiles(activePackPath).length : 0;
-			const gatewayStatus = lastGatewayDecision
-				? [
-					`Gateway: ${lastGatewayDecision.status} (${Math.round(lastGatewayDecision.confidence * 100)}%, ${lastGatewayDecision.backend})`,
-					`  candidates: ${lastGatewayDecision.candidateCount}, injected: ${lastGatewayDecision.injected ? "yes" : "no"}`,
-					`  reason: ${lastGatewayDecision.reason || "<none>"}`,
-					`  at: ${lastGatewayDecision.timestamp}`,
-				]
-				: [`Gateway: ${["gateway", "qmd-economy"].includes(contextPipeline) ? "pending" : "off"}`];
-			const retrieval = lastRetrieval
-				? [
-					`Last retrieval: ${lastRetrieval.mode}`,
-					`  policy: ${lastRetrieval.policy}`,
-					`  query: ${lastRetrieval.query || "<none>"}`,
-					`  queries: ${lastRetrieval.queries.join(" | ") || "<none>"}`,
-					`  results: ${lastRetrieval.resultCount}`,
-					`  duration: ${lastRetrieval.durationMs}ms / ${lastRetrieval.budgetMs}ms${lastRetrieval.timedOut ? " (budget reached)" : ""}`,
-					`  context: ${lastRetrieval.contextMode ?? contextMode}, ~${lastRetrieval.contextEstimatedTokens ?? 0}/${lastRetrieval.contextBudgetTokens ?? contextTokenBudget} tokens (${lastRetrieval.contextChars ?? 0} chars)`,
-					`  cross-pack hits: ${lastRetrieval.crossPackHits.join(", ") || "<none>"}`,
-					`  at: ${lastRetrieval.timestamp}`,
-				]
-				: ["Last retrieval: none"];
-			const selection = lastPackSelection
-				? [
-					`Selection: ${lastPackSelection.confidence} (${lastPackSelection.score})`,
-					`  reasons: ${lastPackSelection.reasons.join("; ") || "<none>"}`,
-				]
-				: ["Selection: <none>"];
-			const switchLines = lastPackSwitch
-				? [`Last switch: ${lastPackSwitch.from || "<none>"} → ${lastPackSwitch.to}`, `  reason: ${lastPackSwitch.reason}`, `  at: ${lastPackSwitch.timestamp}`]
-				: ["Last switch: none"];
-			const lines = [
-				`Profile: ${currentProfile}${currentProfile === "custom" ? ` (base ${baseProfile})` : ""}`,
-				`Config path: ${memctxConfigPath()}`,
-				`Active pack: ${activePack || "<none>"}`,
+	function workspaceStatusLines(ctx: ExtensionContext, advanced = false): string[] {
+		const packsDir = _packsDir || (vaultRoot ? path.join(vaultRoot, "packs") : resolvePacksDir(ctx.cwd) || "");
+		const packFileCount = activePackPath ? scanPackFiles(activePackPath).length : 0;
+		const memoryState = activePack ? "ready" : "not initialized";
+		const search = qmdStatus.available ? `qmd (${qmdStatus.source})` : "grep fallback";
+		const learning = autosaveMode === "off" ? "off" : autosaveMode === "auto" ? "auto" : autosaveMode;
+		const lines = [
+			"🧠 Workspace memory",
+			`Status: ${memoryState}`,
+			`Workspace: ${ctx.cwd}`,
+			`Memory: ${activePack || "<none>"}`,
+			`Search: ${search}`,
+			`Learning: ${learning}`,
+			`Markdown files: ${packFileCount}`,
+			lastRetrieval ? `Last retrieval: ${lastRetrieval.resultCount} hit${lastRetrieval.resultCount === 1 ? "" : "s"} via ${lastRetrieval.mode}` : "Last retrieval: none",
+			lastGatewayDecision ? `Last gateway: ${lastGatewayDecision.status}${lastGatewayDecision.injected ? " (injected)" : ""}` : "Last gateway: pending",
+		];
+		if (advanced) {
+			lines.push(
+				"",
+				"Advanced:",
 				`Pack path: ${activePackPath || "<none>"}`,
 				`Packs dir: ${packsDir || "<none>"}`,
-				`Pack files: ${packFileCount} markdown files`,
-				`Auto-switch: ${autoSwitchMode}`,
-				`Retrieval policy: ${retrievalPolicy}`,
-				`Retrieval budget: ${retrievalLatencyBudgetMs}ms`,
+				`Workspace map: ${packsDir ? workspaceMapPathForPacksDir(packsDir) : "<none>"}`,
+				`Profile: ${currentProfile}${currentProfile === "custom" ? ` (base ${baseProfile})` : ""}`,
+				`Retrieval: ${retrievalPolicy} (${retrievalLatencyBudgetMs}ms)`,
 				`Gateway judge: ${gatewayJudgeMode}`,
-				`Context: ${contextPipeline}/${contextMode}, budget ~${contextTokenBudget} tokens, max items ${contextMaxItems}, strip metadata ${contextStripMetadata ? "on" : "off"}`,
-				`Autosave: ${autosaveMode}`,
-				`Autosave low-confidence queue: ${autosaveQueueLowConfidence ? "on" : "off"}`,
+				`Context: ${contextPipeline}/${contextMode}, ~${contextTokenBudget} tokens, ${contextMaxItems} items`,
 				`Save queue: ${readSaveQueue().length} pending`,
-				...selection,
-				...switchLines,
-				`qmd: ${qmdStatus.available ? "available" : "unavailable"}`,
-				`qmd source: ${qmdStatus.source}`,
 				`qmd bin: ${qmdStatus.bin ?? "<none>"}`,
 				`qmd version: ${qmdStatus.version ?? "<unknown>"}`,
 				`qmd error: ${qmdStatus.error ?? "<none>"}`,
-				`qmd collection: ${qmdCollection || "<none>"}`,
-				`Strict mode: ${strictMode ? "on" : "off"}`,
-				`LLM mode: ${llmMode}`,
-				`LLM calls: ${llmStats.callsThisSession}`,
-				`LLM last use: ${llmStats.lastUseCase ?? "<none>"}`,
-				`LLM last decision: ${llmStats.lastDecision ?? "<none>"}`,
-				`LLM chars: in ${llmStats.estimatedInputChars}, out ${llmStats.estimatedOutputChars}`,
-				`LLM error: ${llmStats.lastError ?? "<none>"}`,
-				...gatewayStatus,
-				...retrieval,
-			];
-			ctx.ui.notify(lines.join("\n"), "info");
-		},
-	};
-	pi.registerCommand("memctx-pack-status", packStatusCommand);
-	pi.registerCommand("pack-status", {
-		...packStatusCommand,
-		description: "Deprecated alias for /memctx-pack-status.",
-	});
+			);
+		}
+		return lines;
+	}
 
-	// --- /memctx-profile command: apply zero-config behavior profiles ---
-	pi.registerCommand("memctx-profile", {
-		description: "Apply the memory gateway profile. Usage: /memctx-profile [gateway|status]",
-		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			if (["gateway", "gateway-lite", "gateway-full"].includes(target)) {
-				const config = profileDefaults("gateway");
-				applyMemctxConfig(config);
-				writeMemctxConfig(config);
-			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-profile [gateway|status]", "error");
-				return;
+	async function refreshWorkspaceMemory(scanDir: string, ctx: ExtensionCommandContext, noDeep = false): Promise<void> {
+		if (!activePackPath || !activePack) {
+			ctx.ui.notify("memctx: No workspace memory found. Run /memctx-init first.", "error");
+			return;
+		}
+		if (packEnrichRunning) {
+			ctx.ui.notify("memctx: Memory refresh is already running in the background.", "warning");
+			return;
+		}
+		if (!fs.existsSync(scanDir)) {
+			ctx.ui.notify(`memctx: Workspace path not found: ${scanDir}`, "error");
+			return;
+		}
+		const pack = activePack;
+		const packPath = activePackPath;
+		const collection = qmdCollection;
+		const useLlm = !noDeep && !!ctx.model;
+		const started = Date.now();
+		packEnrichRunning = true;
+		ctx.ui.notify(`memctx: Refreshing workspace memory in background.\nWorkspace: ${scanDir}\nMemory: ${pack}\nDeep LLM: ${useLlm ? "on" : "off"}`, "info");
+		ctx.ui.setStatus("memctx", `🧠 ${pack} · refreshing memory`);
+		setTimeout(() => void (async () => {
+			try {
+				const files = await enrichGeneratedPackWithLlm(scanDir, pack, packPath, ctx, useLlm);
+				if (qmdAvailable && collection) qmdEmbed(collection, packPath).catch(() => {});
+				ctx.ui.notify(`memctx: Workspace memory refresh complete in ${Date.now() - started}ms\nupdated files: ${files.length}${files.length ? `\n${files.map((f) => `- ${path.relative(packPath, f)}`).slice(0, 12).join("\n")}${files.length > 12 ? "\n- ..." : ""}` : ""}`, "info");
+			} catch (err) {
+				ctx.ui.notify(`memctx: Workspace memory refresh failed after ${Date.now() - started}ms: ${err instanceof Error ? err.message : String(err)}`, "error");
+			} finally {
+				packEnrichRunning = false;
+				ctx.ui.setStatus("memctx", buildStatusText());
 			}
-			ctx.ui.notify([
-				`memctx profile: ${currentProfile}`,
-				`strict: ${strictMode ? "on" : "off"}`,
-				`retrieval: ${retrievalPolicy} (${retrievalLatencyBudgetMs}ms)`,
-				`autosave: ${autosaveMode}`,
-				`llm: ${llmMode}`,
-				`auto-switch: ${autoSwitchMode}`,
-				`gateway judge: ${gatewayJudgeMode}`,
-				`auto-bootstrap: ${autoBootstrapMode}`,
-			].join("\n"), "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
-		},
-	});
+		})(), 0);
+	}
 
-	// --- /memctx-config command: inspect/reset persistent config ---
-	pi.registerCommand("memctx-config", {
-		description: "Show or reset persistent memctx config. Usage: /memctx-config [status|reset]",
-		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			if (target === "reset") {
-				const config = profileDefaults("gateway");
-				applyMemctxConfig(config);
-				writeMemctxConfig(config);
-				ctx.ui.notify("memctx: Config reset to profile:gateway.", "info");
+	async function initializeWorkspaceMemory(args: string, ctx: ExtensionCommandContext): Promise<void> {
+		let packsDir = _packsDir || resolvePacksDir(ctx.cwd) || DEFAULT_GLOBAL_PACKS_DIR;
+		fs.mkdirSync(packsDir, { recursive: true });
+
+		const rawParts = (args ?? "").trim().split(/\s+/).filter(Boolean);
+		const noDeep = rawParts.includes("--no-deep");
+		const parts = rawParts.filter((part) => part !== "--deep" && part !== "deep" && part !== "--no-deep");
+		let scanDir = parts[0] || ctx.cwd;
+		let slug = parts[1] || "";
+		if (!path.isAbsolute(scanDir)) scanDir = path.resolve(ctx.cwd, scanDir);
+		if (!fs.existsSync(scanDir)) {
+			ctx.ui.notify(`memctx: Workspace path not found: ${scanDir}`, "error");
+			return;
+		}
+		if (!slug) slug = path.basename(scanDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "workspace";
+
+		const targetPackPath = path.join(packsDir, slug);
+		if (fs.existsSync(targetPackPath)) {
+			const overwrite = await ctx.ui.confirm("Workspace memory exists", `Memory "${slug}" already exists. Refresh/rebuild it from ${scanDir}?`);
+			if (!overwrite) {
+				_packsDir = packsDir;
+				vaultRoot = path.dirname(packsDir);
+				activePack = slug;
+				activePackPath = targetPackPath;
+				qmdCollection = `memctx-${slug}`;
+				rememberWorkspaceMemory(packsDir, scanDir, slug);
+				if (qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
+				ctx.ui.notify(`memctx: Linked workspace to existing memory "${slug}".`, "info");
 				ctx.ui.setStatus("memctx", buildStatusText());
 				return;
 			}
-			if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-config [status|reset]", "error");
-				return;
-			}
-			ctx.ui.notify(`memctx config: ${memctxConfigPath()}\n${JSON.stringify(currentMemctxConfig(), null, 2)}`, "info");
+			fs.rmSync(targetPackPath, { recursive: true });
+		}
+
+		ctx.ui.notify(`memctx: Initializing workspace memory for ${scanDir}...`, "info");
+		const { packPath, filesCreated } = generatePackFromDirectory(scanDir, slug, packsDir);
+		_packsDir = packsDir;
+		vaultRoot = path.dirname(packsDir);
+		activePack = slug;
+		activePackPath = packPath;
+		qmdCollection = `memctx-${slug}`;
+		lastPackSwitch = { from: "", to: slug, reason: "initialized workspace memory", confidence: "high", timestamp: nowTimestamp() };
+		rememberWorkspaceMemory(packsDir, scanDir, slug);
+
+		ctx.ui.notify(`memctx: Workspace memory "${slug}" initialized.\nWorkspace: ${scanDir}\nFiles created: ${filesCreated.length}\nLearning: ${autosaveMode}\nSearch: ${qmdAvailable ? "qmd" : "grep fallback"}`, "info");
+		ctx.ui.setStatus("memctx", buildStatusText());
+		await refreshWorkspaceMemory(scanDir, ctx, noDeep);
+	}
+
+	pi.registerCommand("memctx", {
+		description: "Show pi-memctx help and workspace memory status. Usage: /memctx",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify([
+				"pi-memctx — local Markdown memory for Pi",
+				"",
+				...workspaceStatusLines(ctx, false),
+				"",
+				"Daily commands:",
+				"  /memctx-init      Create/update memory for this workspace",
+				"  /memctx-status    Show workspace memory status",
+				"  /memctx-refresh   Refresh workspace memory",
+				"  /memctx-doctor    Diagnose setup",
+				"",
+				"Tip: normally you just ask Pi questions. Memory works automatically.",
+			].join("\n"), "info");
 		},
 	});
 
-	// --- /memctx-strict command: toggle strict memory gate ---
-	pi.registerCommand("memctx-strict", {
-		description: "Toggle strict memory retrieval guidance. Usage: /memctx-strict [on|off|status]",
+	pi.registerCommand("memctx-status", {
+		description: "Show workspace memory status. Usage: /memctx-status [--advanced]",
 		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			let changed = false;
-			if (["on", "true", "1", "yes"].includes(target)) {
-				strictMode = true;
-				changed = true;
-			} else if (["off", "false", "0", "no"].includes(target)) {
-				strictMode = false;
-				changed = true;
-			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-strict [on|off|status]", "error");
-				return;
-			}
-			if (changed) markCustomAndPersist();
-			ctx.ui.notify(`memctx: Strict mode ${strictMode ? "on" : "off"}.`, "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
+			const advanced = /--advanced|advanced/i.test(args ?? "");
+			ctx.ui.notify(workspaceStatusLines(ctx, advanced).join("\n"), "info");
 		},
 	});
 
-	// --- /memctx-auto-switch command: toggle cwd/prompt pack switching ---
-	pi.registerCommand("memctx-auto-switch", {
-		description: "Configure automatic pack switching. Usage: /memctx-auto-switch [off|cwd|prompt|all|status]",
+	pi.registerCommand("memctx-init", {
+		description: "Create or update memory for the current workspace. Usage: /memctx-init [path] [name] [--no-deep]",
+		handler: initializeWorkspaceMemory,
+	});
+
+	pi.registerCommand("memctx-refresh", {
+		description: "Refresh memory for the current workspace. Usage: /memctx-refresh [path] [--no-deep]",
 		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			let changed = false;
-			if (["off", "cwd", "prompt", "all"].includes(target)) {
-				autoSwitchMode = target as AutoSwitchMode;
-				changed = true;
-			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-auto-switch [off|cwd|prompt|all|status]", "error");
-				return;
-			}
-			if (changed) markCustomAndPersist();
-			ctx.ui.notify(`memctx: Auto-switch ${autoSwitchMode}.`, "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
+			const rawParts = (args ?? "").trim().split(/\s+/).filter(Boolean);
+			const noDeep = rawParts.includes("--no-deep");
+			const scanArg = rawParts.find((part) => part !== "--deep" && part !== "deep" && part !== "--no-deep");
+			let scanDir = scanArg || ctx.cwd;
+			if (!path.isAbsolute(scanDir)) scanDir = path.resolve(ctx.cwd, scanDir);
+			await refreshWorkspaceMemory(scanDir, ctx, noDeep);
 		},
 	});
 
-	// --- /memctx-llm command: configure LLM assistance ---
-	pi.registerCommand("memctx-llm", {
-		description: "Configure LLM assistance. Usage: /memctx-llm [off|assist|first|status]",
-		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			let changed = false;
-			if (["off", "assist", "first"].includes(target)) {
-				llmMode = target as LlmMode;
-				llmStats.mode = llmMode;
-				changed = true;
-			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-llm [off|assist|first|status]", "error");
-				return;
-			}
-			if (changed) markCustomAndPersist();
-			ctx.ui.notify(`memctx: LLM mode ${llmMode}. Calls this session: ${llmStats.callsThisSession}. Last: ${llmStats.lastUseCase ?? "none"}.`, "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
-		},
-	});
-
-	// --- /memctx-retrieval command: configure automatic retrieval depth ---
-	pi.registerCommand("memctx-retrieval", {
-		description: "Configure automatic memory retrieval. Usage: /memctx-retrieval [auto|fast|balanced|deep|strict|status]",
-		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			let changed = false;
-			if (["auto", "fast", "balanced", "deep", "strict"].includes(target)) {
-				retrievalPolicy = target as RetrievalPolicy;
-				changed = true;
-			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-retrieval [auto|fast|balanced|deep|strict|status]", "error");
-				return;
-			}
-			if (changed) markCustomAndPersist();
-			ctx.ui.notify(`memctx: Retrieval policy ${retrievalPolicy}.`, "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
-		},
-	});
-
-	// --- /memctx-autosave command: configure memory capture behavior ---
-	pi.registerCommand("memctx-autosave", {
-		description: "Configure memory save suggestions. Usage: /memctx-autosave [off|suggest|confirm|auto|status]",
-		handler: async (args, ctx) => {
-			const target = (args ?? "status").trim().toLowerCase();
-			let changed = false;
-			if (["off", "suggest", "confirm", "auto"].includes(target)) {
-				autosaveMode = target as AutosaveMode;
-				changed = true;
-			} else if (target && target !== "status") {
-				ctx.ui.notify("memctx: Usage: /memctx-autosave [off|suggest|confirm|auto|status]", "error");
-				return;
-			}
-			if (changed) markCustomAndPersist();
-			ctx.ui.notify(`memctx: Autosave ${autosaveMode}. Save queue: ${readSaveQueue().length} pending.`, "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
-		},
-	});
-
-	// --- /memctx-save-queue command: review pending memory candidates ---
-	pi.registerCommand("memctx-save-queue", {
-		description: "Review memory save candidates. Usage: /memctx-save-queue [list|approve <id>|reject <id>|clear]",
-		handler: async (args, ctx) => {
-			const [action = "list", id = ""] = (args ?? "").trim().split(/\s+/).filter(Boolean);
-			let queue = readSaveQueue();
-			if (action === "clear") {
-				writeSaveQueue([]);
-				ctx.ui.notify("memctx: Save queue cleared.", "info");
-				return;
-			}
-			if (action === "reject") {
-				queue = queue.filter((item) => item.id !== id);
-				writeSaveQueue(queue);
-				ctx.ui.notify(`memctx: Rejected candidate ${id || "<none>"}.`, "info");
-				return;
-			}
-			if (action === "approve") {
-				const candidate = queue.find((item) => item.id === id);
-				if (!candidate) {
-					ctx.ui.notify(`memctx: Candidate not found: ${id}`, "error");
-					return;
-				}
-				try {
-					const saved = saveMemoryCandidate(candidate);
-					writeSaveQueue(queue.filter((item) => item.id !== id));
-					if (qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
-					ctx.ui.notify(`memctx: Saved candidate to ${saved.rel}`, "info");
-				} catch (err) {
-					ctx.ui.notify(`memctx: Could not save candidate: ${err instanceof Error ? err.message : String(err)}`, "error");
-				}
-				return;
-			}
-			if (queue.length === 0) {
-				ctx.ui.notify("memctx: Save queue is empty.", "info");
-				return;
-			}
-			ctx.ui.notify(queue.map((item) => `${item.id}: ${item.type} · ${item.title} · ${Math.round(item.confidence * 100)}%`).join("\n"), "info");
-		},
-	});
-
-	// --- /memctx-doctor command: diagnose runtime and pack health ---
+	// --- /memctx-doctor command: diagnose runtime and memory health ---
 	pi.registerCommand("memctx-doctor", {
-		description: "Diagnose active memory pack health and runtime configuration. Usage: /memctx-doctor",
+		description: "Diagnose workspace memory health and runtime configuration. Usage: /memctx-doctor",
 		handler: async (_args, ctx) => {
 			const files = activePackPath ? scanPackFiles(activePackPath) : [];
 			const placeholders = files.filter((file) => readFileSafe(file)?.includes("<Add wikilink>")).length;
@@ -4276,16 +4250,18 @@ export default function (pi: ExtensionAPI) {
 				if (seen.has(slug)) duplicateSlugs.add(slug);
 				seen.add(slug);
 			}
+			const packsDir = _packsDir || (vaultRoot ? path.join(vaultRoot, "packs") : "");
 			const lines = [
-				`Pack: ${activePack || "<none>"}`,
+				"🧠 pi-memctx doctor",
+				`Memory: ${activePack || "<none>"}`,
+				`Workspace: ${ctx.cwd}`,
 				`Path: ${activePackPath || "<none>"}`,
 				`Files: ${files.length} markdown`,
 				`qmd: ${qmdStatus.available ? "available" : "unavailable"} (${qmdStatus.source})`,
 				`qmd collection: ${qmdCollection || "<none>"}`,
-				`Retrieval: ${retrievalPolicy}`,
-				`Autosave: ${autosaveMode}`,
-				`LLM: ${llmMode}`,
-				`Strict: ${strictMode ? "on" : "off"}`,
+				`Learning: ${autosaveMode}`,
+				`Search/retrieval: ${retrievalPolicy}`,
+				`Workspace map: ${packsDir ? workspaceMapPathForPacksDir(packsDir) : "<none>"}`,
 				`Save queue: ${readSaveQueue().length} pending`,
 				`Template placeholders: ${placeholders}`,
 				`Possible duplicate slugs: ${duplicateSlugs.size}`,
@@ -4293,229 +4269,6 @@ export default function (pi: ExtensionAPI) {
 			];
 			ctx.ui.notify(lines.join("\n"), possibleSecrets ? "warning" : "info");
 		},
-	});
-
-	// --- /memctx-pack-enrich command: enrich existing pack with LLM/qmd notes ---
-	pi.registerCommand("memctx-pack-enrich", {
-		description: "Deep-enrich the active pack in the background. Usage: /memctx-pack-enrich [source-dir] [--no-deep]",
-		handler: async (args, ctx) => {
-			if (!activePackPath || !activePack) {
-				ctx.ui.notify("memctx: No active pack to enrich.", "error");
-				return;
-			}
-			if (packEnrichRunning) {
-				ctx.ui.notify("memctx enrich: already running in the background. Wait for completion before starting another enrich.", "warning");
-				return;
-			}
-			const rawParts = (args ?? "").trim().split(/\s+/).filter(Boolean);
-			const noDeep = rawParts.includes("--no-deep");
-			let scanDir = rawParts.filter((part) => part !== "--deep" && part !== "deep" && part !== "--no-deep")[0] ?? "";
-			if (!scanDir) {
-				const resource = readFileSafe(path.join(activePackPath, "00-system", "pi-agent", "resource-map.md")) ?? "";
-				scanDir = resource.match(/## Source directory\s*\n\s*`([^`]+)`/m)?.[1] ?? "";
-			}
-			if (!scanDir || !fs.existsSync(scanDir)) {
-				ctx.ui.notify("memctx: Source directory not found. Usage: /memctx-pack-enrich [source-dir] [--no-deep]", "error");
-				return;
-			}
-			const pack = activePack;
-			const packPath = activePackPath;
-			const collection = qmdCollection;
-			const started = Date.now();
-			const useLlm = !noDeep && !!ctx.model;
-			packEnrichRunning = true;
-			ctx.ui.notify(`memctx enrich: started in background for pack ${pack}\nsource: ${scanDir}\ndeep LLM: ${useLlm ? "on" : "off"}\nqmd indexing: ${qmdAvailable ? "background" : "unavailable"}`, "info");
-			ctx.ui.setStatus("memctx", `📦 ${pack} · enriching in background`);
-			setTimeout(() => void (async () => {
-				try {
-					const files = await enrichGeneratedPackWithLlm(scanDir, pack, packPath, ctx, useLlm);
-					if (qmdAvailable && collection) qmdEmbed(collection, packPath).catch(() => {});
-					ctx.ui.notify(`memctx enrich: complete in ${Date.now() - started}ms\nupdated files: ${files.length}\n${files.map((f) => `- ${path.relative(packPath, f)}`).slice(0, 12).join("\n")}${files.length > 12 ? "\n- ..." : ""}`, "info");
-				} catch (err) {
-					ctx.ui.notify(`memctx enrich: failed after ${Date.now() - started}ms: ${err instanceof Error ? err.message : String(err)}`, "error");
-				} finally {
-					packEnrichRunning = false;
-					ctx.ui.setStatus("memctx", buildStatusText());
-				}
-			})(), 0);
-		},
-	});
-
-	// --- /memctx-pack command: list and switch packs ---
-	const packCommand = {
-		description: "List or switch memory packs. Usage: /memctx-pack [name]",
-		handler: async (args: string, ctx: ExtensionCommandContext) => {
-			const packsDir = _packsDir || resolvePacksDir(ctx.cwd);
-			if (!packsDir) {
-				ctx.ui.notify("memctx: No packs found. Use /memctx-pack-generate to create one.", "error");
-				return;
-			}
-
-			const packs = listPacks(packsDir);
-
-			if (packs.length === 0) {
-				ctx.ui.notify("memctx: No packs found.", "info");
-				return;
-			}
-
-			const target = args?.trim();
-
-			if (!target) {
-				// No argument: show picker
-				const options = packs.map((p) =>
-					p === activePack ? `📦 ${p} (active)` : p,
-				);
-
-				const selected = await ctx.ui.select("Select memory pack", options);
-				if (!selected) return;
-
-				// Strip the prefix if it was the active one
-				const packName = selected.replace(/^📦 /, "").replace(/ \(active\)$/, "");
-
-				if (packName === activePack) {
-					ctx.ui.notify(`memctx: Already using pack "${activePack}".`, "info");
-					return;
-				}
-
-				const from = activePack;
-				activePack = packName;
-				activePackPath = path.join(packsDir, packName);
-				qmdCollection = `memctx-${packName}`;
-				lastPackSwitch = { from, to: packName, reason: "manual /memctx-pack selection", confidence: "high", timestamp: nowTimestamp() };
-
-				if (qmdAvailable) {
-					qmdEmbed(qmdCollection, activePackPath).catch(() => {});
-				}
-
-				ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "info");
-				ctx.ui.setStatus("memctx", buildStatusText());
-				return;
-			}
-
-			// Argument provided: switch directly
-			if (!packs.includes(target)) {
-				ctx.ui.notify(`memctx: Pack "${target}" not found. Available: ${packs.join(", ")}`, "error");
-				return;
-			}
-
-			if (target === activePack) {
-				ctx.ui.notify(`memctx: Already using pack "${activePack}".`, "info");
-				return;
-			}
-
-			const from = activePack;
-			activePack = target;
-			activePackPath = path.join(packsDir, target);
-			qmdCollection = `memctx-${target}`;
-			lastPackSwitch = { from, to: target, reason: "manual /memctx-pack argument", confidence: "high", timestamp: nowTimestamp() };
-
-			if (qmdAvailable) {
-				qmdEmbed(qmdCollection, activePackPath).catch(() => {});
-			}
-
-			ctx.ui.notify(`memctx: Switched to pack "${activePack}".`, "info");
-			ctx.ui.setStatus("memctx", buildStatusText());
-		},
-	};
-	pi.registerCommand("memctx-pack", packCommand);
-	pi.registerCommand("pack", {
-		...packCommand,
-		description: "Deprecated alias for /memctx-pack.",
-	});
-
-	// --- /memctx-pack-generate command: generate a pack from a directory ---
-	const packGenerateCommand = {
-		description: "Generate a memory pack from a directory of repos. Usage: /memctx-pack-generate [path] [slug] [--no-deep]",
-		handler: async (args: string, ctx: ExtensionCommandContext) => {
-			// Resolve packs directory — create default if none exists
-			let packsDir = _packsDir;
-			if (!packsDir) {
-				// Try to find existing packs dir
-				const resolvedPacksDir = resolvePacksDir(ctx.cwd);
-				if (resolvedPacksDir) packsDir = resolvedPacksDir;
-			}
-			if (!packsDir) {
-				// Create default global packs directory
-				packsDir = DEFAULT_GLOBAL_PACKS_DIR;
-				fs.mkdirSync(packsDir, { recursive: true });
-			}
-
-			const rawParts = (args ?? "").trim().split(/\s+/).filter(Boolean);
-			const noDeep = rawParts.includes("--no-deep");
-			const parts = rawParts.filter((part) => part !== "--deep" && part !== "deep" && part !== "--no-deep");
-			let scanDir = parts[0] || ctx.cwd;
-			let slug = parts[1] || "";
-
-			// Resolve relative paths
-			if (!path.isAbsolute(scanDir)) {
-				scanDir = path.resolve(ctx.cwd, scanDir);
-			}
-
-			if (!fs.existsSync(scanDir)) {
-				ctx.ui.notify(`memctx: Directory not found: ${scanDir}`, "error");
-				return;
-			}
-
-			// Derive slug from directory name if not provided
-			if (!slug) {
-				slug = path.basename(scanDir).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-			}
-
-			const targetPackPath = path.join(packsDir, slug);
-			if (fs.existsSync(targetPackPath)) {
-				const overwrite = await ctx.ui.confirm(
-					"Pack exists",
-					`Pack "${slug}" already exists at ${targetPackPath}. Overwrite?`,
-				);
-				if (!overwrite) return;
-				fs.rmSync(targetPackPath, { recursive: true });
-			}
-
-			ctx.ui.notify(`memctx: Scanning ${scanDir}...`, "info");
-
-			const { packPath, filesCreated } = generatePackFromDirectory(scanDir, slug, packsDir);
-
-			// Auto-switch to the new pack immediately after deterministic generation.
-			_packsDir = packsDir;
-			vaultRoot = path.dirname(packsDir);
-			activePack = slug;
-			activePackPath = packPath;
-			qmdCollection = `memctx-${slug}`;
-			lastPackSwitch = { from: "", to: slug, reason: "generated new pack", confidence: "high", timestamp: nowTimestamp() };
-
-			const useLlm = !noDeep && !!ctx.model;
-			ctx.ui.notify(
-				`memctx: Pack "${slug}" generated with ${filesCreated.length} files from ${scanDir}${useLlm ? "\nmemctx: Deep enrichment started in background." : "\nmemctx: Deep enrichment skipped (no selected model or --no-deep)."}`,
-				"info",
-			);
-			ctx.ui.setStatus("memctx", buildStatusText());
-
-			if (packEnrichRunning) {
-				ctx.ui.notify("memctx: Another enrichment job is already running; generated pack will be indexed only.", "warning");
-				if (qmdAvailable) qmdEmbed(qmdCollection, packPath).catch(() => {});
-				return;
-			}
-
-			packEnrichRunning = true;
-			setTimeout(() => void (async () => {
-				const started = Date.now();
-				try {
-					const enriched = useLlm ? await enrichGeneratedPackWithLlm(scanDir, slug, packPath, ctx, true) : [];
-					if (qmdAvailable) qmdEmbed(qmdCollection, packPath).catch(() => {});
-					ctx.ui.notify(`memctx: Background ${useLlm ? "deep enrichment and " : ""}indexing complete for "${slug}" in ${Date.now() - started}ms${enriched.length ? `\nupdated files: ${enriched.length}` : ""}`, "info");
-				} catch (err) {
-					ctx.ui.notify(`memctx: Background enrichment failed for "${slug}": ${err instanceof Error ? err.message : String(err)}`, "error");
-				} finally {
-					packEnrichRunning = false;
-					ctx.ui.setStatus("memctx", buildStatusText());
-				}
-			})(), 0);
-		},
-	};
-	pi.registerCommand("memctx-pack-generate", packGenerateCommand);
-	pi.registerCommand("pack-generate", {
-		...packGenerateCommand,
-		description: "Deprecated alias for /memctx-pack-generate.",
 	});
 
 	// --- memctx_search tool ---
@@ -4584,7 +4337,7 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				const hint = crossResults.length > 0
-					? "\n\nTry switching pack: " + crossResults.map((p) => "/memctx-pack " + p).join(", ")
+					? "\n\nRelated memory may exist in: " + crossResults.join(", ")
 					: "";
 
 				return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",

--- a/test/e2e.ts
+++ b/test/e2e.ts
@@ -108,17 +108,15 @@ async function main() {
 
 	assert(!!tools.memctx_search, "memctx_search tool registered");
 	assert(!!tools.memctx_save, "memctx_save tool registered");
-	assert(!!commands["memctx-pack"], "/memctx-pack command registered");
-	assert(!!commands.pack, "/pack deprecated alias registered");
-	assert(!!commands["memctx-pack-generate"], "/memctx-pack-generate command registered");
-	assert(!!commands["pack-generate"], "/pack-generate deprecated alias registered");
-	assert(!!commands["memctx-retrieval"], "/memctx-retrieval command registered");
-	assert(!!commands["memctx-autosave"], "/memctx-autosave command registered");
-	assert(!!commands["memctx-save-queue"], "/memctx-save-queue command registered");
+	assert(!!commands["memctx"], "/memctx command registered");
+	assert(!!commands["memctx-init"], "/memctx-init command registered");
+	assert(!!commands["memctx-status"], "/memctx-status command registered");
+	assert(!!commands["memctx-refresh"], "/memctx-refresh command registered");
 	assert(!!commands["memctx-doctor"], "/memctx-doctor command registered");
-	assert(!!commands["memctx-pack-enrich"], "/memctx-pack-enrich command registered");
-	assert(!!commands["memctx-profile"], "/memctx-profile command registered");
-	assert(!!commands["memctx-config"], "/memctx-config command registered");
+	assert(!commands["memctx-pack"], "/memctx-pack command removed from public surface");
+	assert(!commands["memctx-pack-generate"], "/memctx-pack-generate command removed from public surface");
+	assert(!commands["memctx-retrieval"], "/memctx-retrieval command removed from public surface");
+	assert(!commands["memctx-autosave"], "/memctx-autosave command removed from public surface");
 	assert(!!hooks.session_start, "session_start hook registered");
 	assert(!!hooks.before_agent_start, "before_agent_start hook registered");
 	assert(!!hooks.session_before_compact, "session_before_compact hook registered");

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -869,50 +869,26 @@ describe("extension registration", () => {
 		expect(hooks["session_shutdown"]).toBeDefined();
 	});
 
-	test("registers /memctx-pack command and deprecated /pack alias", () => {
+	test("registers only the simplified public command surface", () => {
 		const { pi, commands } = createMockPi();
 		registerExtension(pi as any);
 
-		expect(commands["memctx-pack"]).toBeDefined();
-		expect(commands["memctx-pack"].description).toContain("switch");
-		expect(commands["pack"]).toBeDefined();
-		expect(commands["pack"].description).toContain("Deprecated alias");
+		for (const command of ["memctx", "memctx-init", "memctx-status", "memctx-refresh", "memctx-doctor"]) {
+			expect(commands[command]).toBeDefined();
+		}
+		for (const removed of ["memctx-pack", "pack", "memctx-pack-status", "pack-status", "memctx-strict", "memctx-pack-generate", "pack-generate", "memctx-retrieval", "memctx-autosave", "memctx-save-queue", "memctx-pack-enrich", "memctx-profile", "memctx-config"]) {
+			expect(commands[removed]).toBeUndefined();
+		}
 	});
 
-	test("registers /memctx-pack-status and /memctx-strict commands", () => {
-		const { pi, commands } = createMockPi();
-		registerExtension(pi as any);
-
-		expect(commands["memctx-pack-status"]).toBeDefined();
-		expect(commands["memctx-pack-status"].description).toContain("status");
-		expect(commands["pack-status"]).toBeDefined();
-		expect(commands["pack-status"].description).toContain("Deprecated alias");
-		expect(commands["memctx-strict"]).toBeDefined();
-		expect(commands["memctx-strict"].description).toContain("strict");
-		expect(commands["memctx-pack-generate"]).toBeDefined();
-		expect(commands["pack-generate"]).toBeDefined();
-		expect(commands["pack-generate"].description).toContain("Deprecated alias");
-		expect(commands["memctx-retrieval"]).toBeDefined();
-		expect(commands["memctx-autosave"]).toBeDefined();
-		expect(commands["memctx-save-queue"]).toBeDefined();
-		expect(commands["memctx-doctor"]).toBeDefined();
-		expect(commands["memctx-pack-enrich"]).toBeDefined();
-		expect(commands["memctx-profile"]).toBeDefined();
-		expect(commands["memctx-config"]).toBeDefined();
-	});
-
-
-	test("/memctx-strict updates the status overlay", async () => {
+	test("/memctx-status shows workspace memory status", async () => {
 		const { pi, commands } = createMockPi();
 		registerExtension(pi as any);
 		const ctx = createMockCtx();
 
-		await commands["memctx-strict"].handler("off", ctx);
-		expect(ctx.ui.setStatus).toHaveBeenCalled();
-		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("learn auto");
-
-		await commands["memctx-strict"].handler("on", ctx);
-		expect((ctx.ui.setStatus.mock.calls.at(-1) as any)?.[1]).toContain("profile:gateway");
+		await commands["memctx-status"].handler("", ctx);
+		expect(ctx.ui.notify).toHaveBeenCalled();
+		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain("Workspace memory");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Shift the public UX from user-managed packs to workspace memory.
- Add simplified commands: `/memctx`, `/memctx-init`, `/memctx-status`, `/memctx-refresh`, `/memctx-doctor`.
- Remove noisy pack/profile/retrieval/autosave commands from the public command surface.
- Add workspace path mapping so initialized memory resolves automatically from the current directory/subdirectories.
- Simplify the status overlay and update README/docs around workspace memory.
- Bump to v0.11.0.

## Validation
- npm run ci
- npm pack includes runtime files
- grep check found no private project references in repo files
