### PR TITLE
Fix duplicate learned memory UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.11.1] - 2026-05-03
+
+### Fixed
+
+- Avoid duplicating the learned-memory post-turn UI by showing only the emoji widget summary.
+
+
 ## [0.11.0] - 2026-05-03
 
 ### Changed

--- a/index.ts
+++ b/index.ts
@@ -4541,7 +4541,6 @@ export default function (pi: ExtensionAPI) {
 		if (savedItems.length > 0 && ctx.hasUI) {
 			const visibleSavedItems = uniqueSavedMemoryItems(savedItems);
 			const lines = visibleSavedItems.map((item) => `   - ${item.type}: ${memoryWikilink(item.rel, item.title)} (${item.action})`);
-			ctx.ui.notify([`memctx: learned ${visibleSavedItems.length} memor${visibleSavedItems.length === 1 ? "y" : "ies"}:`, ...lines].join("\n"), "info");
 			ctx.ui.setWidget("memctx-learned", [
 				`\x1b[32m🧠 memctx learned ${visibleSavedItems.length} memor${visibleSavedItems.length === 1 ? "y" : "ies"}\x1b[0m`,
 				...lines,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memctx",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memctx",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-memctx",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Automatic memory context injection for pi coding agent. Load, search, and persist knowledge across sessions using Markdown packs.",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- remove the non-emoji learned-memory notification
- keep the emoji learned-memory widget summary
- bump package version to 0.11.1 and update changelog

## Validation
- npm run typecheck
- npm test *(fails: existing Bun/@sinclair/typebox ESM export error: Export named 'Type' not found)*