### PR TITLE
fix: enable GitHub Pages workflow setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Upload static site
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- allow configure-pages to enable Pages for GitHub Actions deployments

## Validation
- previous Pages run failed because the repository Pages site was not enabled/configured for GitHub Actions
- this sets actions/configure-pages enablement to true