### PR TITLE
feat: add queued memory review command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add `/memctx-review` to list, approve, reject, clear, and locate queued memory candidates for the active workspace memory.
+
 ## [0.13.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -291,10 +291,31 @@ Most users only need the daily commands:
 | `/memctx` | Show compact help and current memory status. |
 | `/memctx-init` | Create/update memory for this workspace. If a model is selected, deep LLM enrichment starts in the background by default; use `--no-deep` to skip it. |
 | `/memctx-status` | Show workspace memory status; add `--advanced` for internal paths/config. |
+| `/memctx-review` | Review queued memory candidates; approve, reject, clear, or inspect the queue path. |
 | `/memctx-refresh` | Refresh workspace memory inventory/enrichment in the background. |
 | `/memctx-doctor` | Diagnose qmd, workspace memory, and configuration. |
 
 Older pack/config commands were removed from the public command surface to keep the extension simple. Advanced behavior is still configurable through environment variables and the local config file.
+
+### Reviewing queued memory candidates
+
+When automatic learning is unsure whether a candidate should be persisted, pi-memctx queues it for review instead of silently saving it. Review the active workspace queue with:
+
+```txt
+/memctx-review
+```
+
+Useful forms:
+
+```txt
+/memctx-review --list
+/memctx-review approve 1
+/memctx-review reject 1
+/memctx-review clear
+/memctx-review path
+```
+
+By default, review commands operate only on the active workspace memory pack. Advanced users can inspect the raw queue at `~/.cache/pi-memctx/save-queue.json`.
 
 ## Tools
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,6 +96,14 @@ Ask the agent to save durable memory:
 Save this as a decision: we use deterministic e2e packs for integration tests.
 ```
 
+Review queued automatic-learning candidates:
+
+```txt
+/memctx-review
+/memctx-review approve 1
+/memctx-review reject 1
+```
+
 ## Advanced configuration
 
 Most users should keep defaults. Advanced behavior can be controlled with environment variables or `~/.config/pi-memctx/config.json`:

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -28,6 +28,26 @@ memctx: learned 5 memories:
 
 Learned notes are cross-linked with `[[wikilinks]]` to improve navigation and future retrieval.
 
+## Reviewing queued candidates
+
+When automatic learning is not confident enough to save directly, pi-memctx queues memory candidates for review. Run:
+
+```txt
+/memctx-review
+```
+
+Common actions:
+
+```txt
+/memctx-review --list       # show queued candidates for the active workspace memory
+/memctx-review approve 1    # save candidate 1 into the active Markdown pack
+/memctx-review reject 1     # discard candidate 1 without saving
+/memctx-review clear        # discard all queued candidates for the active workspace memory
+/memctx-review path         # show the raw queue path
+```
+
+The raw queue lives at `~/.cache/pi-memctx/save-queue.json`, but approving through `/memctx-review` is preferred because it reuses the same normalization, secret blocking, and Markdown-writing path as `memctx_save`.
+
 ## Explicit saves
 
 The `memctx_save` tool remains available to the agent when you explicitly ask it to remember something:

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -40,4 +40,4 @@ Good memory notes include:
 - Do not persist sensitive data.
 - Prefer safe pointers to secret stores over copied credentials.
 - Keep context notes specific, dated, and reviewable.
-- Review autosave candidates before approving them, especially before sharing a pack.
+- Review autosave candidates with `/memctx-review` before approving them, especially before sharing a pack.

--- a/index.ts
+++ b/index.ts
@@ -2976,8 +2976,10 @@ ${content}
 `;
 }
 
-const SAVE_QUEUE_DIR = path.join(process.env.HOME ?? process.env.USERPROFILE ?? ".", ".cache", "pi-memctx");
-const SAVE_QUEUE_PATH = path.join(SAVE_QUEUE_DIR, "save-queue.json");
+function saveQueuePath(): string {
+	return process.env.MEMCTX_SAVE_QUEUE_PATH
+		?? path.join(process.env.HOME ?? process.env.USERPROFILE ?? ".", ".cache", "pi-memctx", "save-queue.json");
+}
 
 function sensitivePatternHit(title: string, content: string): boolean {
 	const sensitivePatterns = [
@@ -2992,7 +2994,7 @@ function sensitivePatternHit(title: string, content: string): boolean {
 
 function readSaveQueue(): MemoryCandidate[] {
 	try {
-		const raw = readFileSafe(SAVE_QUEUE_PATH);
+		const raw = readFileSafe(saveQueuePath());
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		return Array.isArray(parsed) ? parsed : [];
@@ -3002,8 +3004,9 @@ function readSaveQueue(): MemoryCandidate[] {
 }
 
 function writeSaveQueue(queue: MemoryCandidate[]) {
-	fs.mkdirSync(SAVE_QUEUE_DIR, { recursive: true });
-	fs.writeFileSync(SAVE_QUEUE_PATH, JSON.stringify(queue.slice(-100), null, 2) + "\n", "utf-8");
+	const filePath = saveQueuePath();
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(queue.slice(-100), null, 2) + "\n", "utf-8");
 }
 
 function enqueueMemoryCandidate(candidate: MemoryCandidate) {
@@ -3011,6 +3014,59 @@ function enqueueMemoryCandidate(candidate: MemoryCandidate) {
 	const queue = readSaveQueue();
 	const duplicate = queue.some((item) => item.pack === normalizedCandidate.pack && slugify(normalizeNoteTitle(item.type, item.title)) === slugify(normalizedCandidate.title));
 	if (!duplicate) writeSaveQueue([...queue, normalizedCandidate]);
+}
+
+function queuedMemoryCandidates(pack = activePack): MemoryCandidate[] {
+	const queue = readSaveQueue();
+	return pack ? queue.filter((candidate) => candidate.pack === pack) : queue;
+}
+
+function resolveQueuedMemoryCandidate(selector: string, pack = activePack): { candidate: MemoryCandidate; queueIndex: number; displayIndex: number } | null {
+	const trimmed = selector.trim();
+	if (!trimmed) return null;
+	const queue = readSaveQueue();
+	const scoped = queue
+		.map((candidate, queueIndex) => ({ candidate, queueIndex }))
+		.filter((item) => !pack || item.candidate.pack === pack);
+	if (/^\d+$/.test(trimmed)) {
+		const displayIndex = Number(trimmed);
+		const item = scoped[displayIndex - 1];
+		return item ? { ...item, displayIndex } : null;
+	}
+	const matches = scoped.filter((item) => item.candidate.id === trimmed || item.candidate.id.startsWith(trimmed));
+	if (matches.length !== 1) return null;
+	return { ...matches[0], displayIndex: scoped.findIndex((item) => item.queueIndex === matches[0].queueIndex) + 1 };
+}
+
+function removeQueuedMemoryCandidate(selector: string, pack = activePack): MemoryCandidate | null {
+	const resolved = resolveQueuedMemoryCandidate(selector, pack);
+	if (!resolved) return null;
+	const queue = readSaveQueue();
+	const [removed] = queue.splice(resolved.queueIndex, 1);
+	writeSaveQueue(queue);
+	return removed ?? null;
+}
+
+function clearQueuedMemoryCandidates(pack = activePack): number {
+	const queue = readSaveQueue();
+	const next = pack ? queue.filter((candidate) => candidate.pack !== pack) : [];
+	const removed = queue.length - next.length;
+	writeSaveQueue(next);
+	return removed;
+}
+
+function formatQueuedMemoryCandidate(candidate: MemoryCandidate, index: number, includePreview = false): string {
+	const confidence = Math.round(candidate.confidence * 100);
+	const tags = candidate.tags.length ? candidate.tags.join(", ") : "none";
+	const lines = [
+		`[${index}] ${candidate.type} · ${confidence}% · ${candidate.title}`,
+		`    id: ${candidate.id}`,
+		`    reason: ${candidate.reason}`,
+		`    created: ${candidate.createdAt}`,
+		`    tags: ${tags}`,
+	];
+	if (includePreview) lines.push(`    preview: ${truncate(candidate.content.replace(/\s+/g, " ").trim(), 420)}`);
+	return lines.join("\n");
 }
 
 function exactContextTargetNote(candidate: MemoryCandidate): string | null {
@@ -4541,7 +4597,7 @@ export default function (pi: ExtensionAPI) {
 				const queueCount = readSaveQueue().length;
 				const warnings = [
 					!qmdAvailable ? "qmd unavailable; using grep fallback" : "",
-					queueCount > 0 ? `${queueCount} memory candidate${queueCount === 1 ? "" : "s"} pending review` : "",
+					queueCount > 0 ? `${queueCount} memory candidate${queueCount === 1 ? "" : "s"} pending review; run /memctx-review` : "",
 				].filter(Boolean);
 				if (warnings.length > 0) ctx.ui.notify(`memctx doctor: ${warnings.join("; ")}`, "warning");
 			}
@@ -4744,7 +4800,7 @@ export default function (pi: ExtensionAPI) {
 				`Retrieval: ${retrievalPolicy} (${retrievalLatencyBudgetMs}ms)`,
 				`Gateway judge: ${gatewayJudgeMode}`,
 				`Context: ${contextPipeline}/${contextMode}, ~${contextTokenBudget} tokens, ${contextMaxItems} items`,
-				`Save queue: ${readSaveQueue().length} pending`,
+				`Save queue: ${queuedMemoryCandidates(activePack).length} pending${queuedMemoryCandidates(activePack).length > 0 ? " — run /memctx-review" : ""}`,
 				`qmd bin: ${qmdStatus.bin ?? "<none>"}`,
 				`qmd version: ${qmdStatus.version ?? "<unknown>"}`,
 				`qmd error: ${qmdStatus.error ?? "<none>"}`,
@@ -4848,6 +4904,7 @@ export default function (pi: ExtensionAPI) {
 				"Daily commands:",
 				"  /memctx-init      Create/update memory for this workspace",
 				"  /memctx-status    Show workspace memory status",
+				"  /memctx-review    Review queued memory candidates",
 				"  /memctx-refresh   Refresh workspace memory",
 				"  /memctx-doctor    Diagnose setup",
 				"",
@@ -4861,6 +4918,99 @@ export default function (pi: ExtensionAPI) {
 		handler: async (args, ctx) => {
 			const advanced = /--advanced|advanced/i.test(args ?? "");
 			ctx.ui.notify(workspaceStatusLines(ctx, advanced).join("\n"), "info");
+		},
+	});
+
+	pi.registerCommand("memctx-review", {
+		description: "Review queued memory candidates. Usage: /memctx-review [--list|approve <id|index>|reject <id|index>|clear|path]",
+		handler: async (args, ctx) => {
+			const rawParts = (args ?? "").trim().split(/\s+/).filter(Boolean);
+			const action = (rawParts[0] ?? "--list").toLowerCase();
+			const selector = rawParts[1] ?? "";
+			if (["path", "--path"].includes(action)) {
+				ctx.ui.notify(`Memory candidate queue: ${saveQueuePath()}`, "info");
+				return;
+			}
+			if (!activePack) {
+				ctx.ui.notify("memctx: No active workspace memory. Run /memctx-init first, or use /memctx-review path for manual queue inspection.", "warning");
+				return;
+			}
+
+			if (["approve", "save"].includes(action)) {
+				if (!selector) {
+					ctx.ui.notify("Usage: /memctx-review approve <id|index>", "warning");
+					return;
+				}
+				const resolved = resolveQueuedMemoryCandidate(selector, activePack);
+				if (!resolved) {
+					ctx.ui.notify(`memctx: No queued memory candidate matched \"${selector}\" for ${activePack}.`, "warning");
+					return;
+				}
+				try {
+					const saved = saveMemoryCandidate(resolved.candidate);
+					removeQueuedMemoryCandidate(resolved.candidate.id, activePack);
+					if (qmdAvailable) qmdEmbed(qmdCollection, activePackPath).catch(() => {});
+					ctx.ui.notify([
+						`Saved queued memory candidate: ${saved.action === "updated" ? "updated" : "created"} ${saved.rel}`,
+						`Type: ${resolved.candidate.type}`,
+						`Title: ${resolved.candidate.title}`,
+						`Remaining queue: ${queuedMemoryCandidates(activePack).length} pending`,
+					].join("\n"), "info");
+				} catch (err) {
+					ctx.ui.notify(`memctx: Could not save queued candidate: ${err instanceof Error ? err.message : String(err)}`, "error");
+				}
+				return;
+			}
+
+			if (["reject", "discard", "remove", "delete"].includes(action)) {
+				if (!selector) {
+					ctx.ui.notify("Usage: /memctx-review reject <id|index>", "warning");
+					return;
+				}
+				const removed = removeQueuedMemoryCandidate(selector, activePack);
+				if (!removed) {
+					ctx.ui.notify(`memctx: No queued memory candidate matched \"${selector}\" for ${activePack}.`, "warning");
+					return;
+				}
+				ctx.ui.notify([
+					`Discarded queued memory candidate: ${removed.type}: ${removed.title}`,
+					`Remaining queue: ${queuedMemoryCandidates(activePack).length} pending`,
+				].join("\n"), "info");
+				return;
+			}
+
+			if (["clear", "--clear"].includes(action)) {
+				const count = queuedMemoryCandidates(activePack).length;
+				if (count === 0) {
+					ctx.ui.notify(`No queued memory candidates for ${activePack}.`, "info");
+					return;
+				}
+				const confirmed = await ctx.ui.confirm("Discard queued memory candidates?", `Discard all ${count} queued memory candidate${count === 1 ? "" : "s"} for ${activePack}?`);
+				if (!confirmed) {
+					ctx.ui.notify("memctx: Review queue unchanged.", "info");
+					return;
+				}
+				const removed = clearQueuedMemoryCandidates(activePack);
+				ctx.ui.notify(`Discarded ${removed} queued memory candidate${removed === 1 ? "" : "s"} for ${activePack}.`, "info");
+				return;
+			}
+
+			if (!["--list", "list", ""].includes(action)) {
+				ctx.ui.notify("Usage: /memctx-review [--list|approve <id|index>|reject <id|index>|clear|path]", "warning");
+				return;
+			}
+			const candidates = queuedMemoryCandidates(activePack);
+			if (candidates.length === 0) {
+				ctx.ui.notify(`No queued memory candidates for ${activePack}.\nQueue path: ${saveQueuePath()}`, "info");
+				return;
+			}
+			ctx.ui.notify([
+				`${candidates.length} memory candidate${candidates.length === 1 ? "" : "s"} pending for ${activePack}`,
+				"",
+				...candidates.map((candidate, index) => formatQueuedMemoryCandidate(candidate, index + 1, true)),
+				"",
+				"Use /memctx-review approve <index> to save, /memctx-review reject <index> to discard, or /memctx-review clear to discard all for this workspace.",
+			].join("\n"), "info");
 		},
 	});
 
@@ -4907,7 +5057,7 @@ export default function (pi: ExtensionAPI) {
 				`Learning: ${autosaveMode}`,
 				`Search/retrieval: ${retrievalPolicy}`,
 				`Workspace map: ${packsDir ? workspaceMapPathForPacksDir(packsDir) : "<none>"}`,
-				`Save queue: ${readSaveQueue().length} pending`,
+				`Save queue: ${queuedMemoryCandidates(activePack).length} pending${queuedMemoryCandidates(activePack).length > 0 ? " — run /memctx-review" : ""}`,
 				`Template placeholders: ${placeholders}`,
 				`Possible duplicate slugs: ${duplicateSlugs.size}`,
 				`Secret scan warnings: ${possibleSecrets}`,
@@ -5195,7 +5345,7 @@ export default function (pi: ExtensionAPI) {
 		if (queuedCount > 0 && ctx.hasUI) {
 			ctx.ui.setWidget("memctx-learn", [
 				`\x1b[33m💡 memctx: ${queuedCount} memory candidate${queuedCount === 1 ? "" : "s"} queued for review.\x1b[0m`,
-				"   Review later if needed.",
+				"   Run /memctx-review to review, save, or discard queued candidates.",
 			]);
 			setTimeout(() => ctx.hasUI && ctx.ui.setWidget("memctx-learn", []), 30000);
 		}

--- a/test/e2e.ts
+++ b/test/e2e.ts
@@ -111,6 +111,7 @@ async function main() {
 	assert(!!commands["memctx"], "/memctx command registered");
 	assert(!!commands["memctx-init"], "/memctx-init command registered");
 	assert(!!commands["memctx-status"], "/memctx-status command registered");
+	assert(!!commands["memctx-review"], "/memctx-review command registered");
 	assert(!!commands["memctx-refresh"], "/memctx-refresh command registered");
 	assert(!!commands["memctx-doctor"], "/memctx-doctor command registered");
 	assert(!commands["memctx-pack"], "/memctx-pack command removed from public surface");

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -51,11 +51,13 @@ let tmpDir: string;
 function setupTmpDir() {
 	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "amv-test-"));
 	process.env.MEMCTX_CONFIG_PATH = path.join(tmpDir, "config.json");
+	process.env.MEMCTX_SAVE_QUEUE_PATH = path.join(tmpDir, "save-queue.json");
 }
 
 function cleanupTmpDir() {
 	_resetState();
 	delete process.env.MEMCTX_CONFIG_PATH;
+	delete process.env.MEMCTX_SAVE_QUEUE_PATH;
 	fs.rmSync(tmpDir, { recursive: true, force: true });
 }
 
@@ -270,6 +272,31 @@ function createMockCtx(sessionId = "abcdef1234567890") {
 			confirm: mock(async () => false),
 		},
 		cwd: tmpDir,
+	};
+}
+
+function writeSaveQueueForTest(candidates: any[]) {
+	const filePath = process.env.MEMCTX_SAVE_QUEUE_PATH!;
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(candidates, null, 2) + "\n");
+}
+
+function readSaveQueueForTest(): any[] {
+	return JSON.parse(fs.readFileSync(process.env.MEMCTX_SAVE_QUEUE_PATH!, "utf-8"));
+}
+
+function queuedCandidate(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "mem-test-1",
+		type: "observation",
+		title: "Queued deploy pattern",
+		content: "Deployment uses a release checklist before production rollout.",
+		tags: ["autolearn", "deploy"],
+		confidence: 0.82,
+		reason: "Unit test candidate",
+		createdAt: "2026-05-09 12:00:00",
+		pack: "test-pack",
+		...overrides,
 	};
 }
 
@@ -901,7 +928,7 @@ describe("extension registration", () => {
 		const { pi, commands } = createMockPi();
 		registerExtension(pi as any);
 
-		for (const command of ["memctx", "memctx-init", "memctx-status", "memctx-refresh", "memctx-doctor"]) {
+		for (const command of ["memctx", "memctx-init", "memctx-status", "memctx-review", "memctx-refresh", "memctx-doctor"]) {
 			expect(commands[command]).toBeDefined();
 		}
 		for (const removed of ["memctx-pack", "pack", "memctx-pack-status", "pack-status", "memctx-strict", "memctx-pack-generate", "pack-generate", "memctx-retrieval", "memctx-autosave", "memctx-save-queue", "memctx-pack-enrich", "memctx-profile", "memctx-config"]) {
@@ -917,6 +944,98 @@ describe("extension registration", () => {
 		await commands["memctx-status"].handler("", ctx);
 		expect(ctx.ui.notify).toHaveBeenCalled();
 		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain("Workspace memory");
+	});
+
+	test("/memctx-review lists queued candidates for the active pack only", async () => {
+		const { packPath } = createTestVault();
+		writeSaveQueueForTest([
+			queuedCandidate(),
+			queuedCandidate({ id: "mem-other", title: "Other pack", pack: "other-pack" }),
+		]);
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		const ctx = createMockCtx();
+
+		await commands["memctx-review"].handler("--list", ctx);
+		const message = (ctx.ui.notify.mock.calls.at(-1) as any)?.[0];
+		expect(message).toContain("1 memory candidate pending for test-pack");
+		expect(message).toContain("Queued deploy pattern");
+		expect(message).not.toContain("Other pack");
+	});
+
+	test("/memctx-review approve saves candidate and removes it from the queue", async () => {
+		const { packPath } = createTestVault();
+		writeSaveQueueForTest([queuedCandidate()]);
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		const ctx = createMockCtx();
+
+		await commands["memctx-review"].handler("approve 1", ctx);
+
+		const savedPath = path.join(packPath, "60-observations", "queued-deploy-pattern.md");
+		expect(fs.existsSync(savedPath)).toBe(true);
+		expect(readSaveQueueForTest()).toHaveLength(0);
+		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain("Saved queued memory candidate");
+	});
+
+	test("/memctx-review reject discards candidate without saving", async () => {
+		const { packPath } = createTestVault();
+		writeSaveQueueForTest([queuedCandidate()]);
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		const ctx = createMockCtx();
+
+		await commands["memctx-review"].handler("reject 1", ctx);
+
+		expect(fs.existsSync(path.join(packPath, "60-observations", "queued-deploy-pattern.md"))).toBe(false);
+		expect(readSaveQueueForTest()).toHaveLength(0);
+		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain("Discarded queued memory candidate");
+	});
+
+	test("/memctx-review clear removes only active-pack candidates after confirmation", async () => {
+		const { packPath } = createTestVault();
+		writeSaveQueueForTest([
+			queuedCandidate(),
+			queuedCandidate({ id: "mem-other", pack: "other-pack" }),
+		]);
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		const ctx = createMockCtx();
+		ctx.ui.confirm = mock(async () => true);
+
+		await commands["memctx-review"].handler("clear", ctx);
+
+		const queue = readSaveQueueForTest();
+		expect(queue).toHaveLength(1);
+		expect(queue[0].pack).toBe("other-pack");
+		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain("Discarded 1 queued memory candidate");
+	});
+
+	test("/memctx-review keeps secret-looking candidates queued when approval is blocked", async () => {
+		const { packPath } = createTestVault();
+		writeSaveQueueForTest([queuedCandidate({ content: "password: super-secret" })]);
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		_setActivePack("test-pack", packPath);
+		const ctx = createMockCtx();
+
+		await commands["memctx-review"].handler("approve 1", ctx);
+
+		expect(readSaveQueueForTest()).toHaveLength(1);
+		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain("Could not save queued candidate");
+	});
+
+	test("/memctx-review path exposes the queue file path", async () => {
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+		const ctx = createMockCtx();
+
+		await commands["memctx-review"].handler("path", ctx);
+		expect((ctx.ui.notify.mock.calls.at(-1) as any)?.[0]).toContain(process.env.MEMCTX_SAVE_QUEUE_PATH!);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Add `/memctx-review` for listing, approving, rejecting, clearing, and locating queued memory candidates
- Scope review operations to the active workspace memory pack by default
- Document the queued-candidate review workflow and point status/doctor/post-turn hints to the new command

Closes #68

## Tests
- `npm run ci`