### PR TITLE
chore: add stale issue and PR automation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
+        with:
+          stale-issue-message: "This issue has been inactive for 60 days. It will be closed in 14 days unless there is new activity."
+          stale-pr-message: "This PR has been inactive for 30 days. It will be closed in 14 days unless there is new activity."
+          days-before-issue-stale: 60
+          days-before-pr-stale: 30
+          days-before-close: 14
+          exempt-issue-labels: "security,breaking-change"
+          exempt-pr-labels: "security,breaking-change"


### PR DESCRIPTION
## Summary

Add weekly stale automation to prevent zombie issues and PRs.

## Configuration

| Setting | Value |
|---------|-------|
| Issues stale after | 60 days |
| PRs stale after | 30 days |
| Close after stale | 14 days |
| Exempt labels | security, breaking-change |
| Schedule | Weekly (Monday 06:00 UTC) |

## Type of change

- [x] CI / tooling

## Security and privacy checklist

- [x] Safe for public repository.
- [x] No sensitive data.

## User impact

None — only affects long-inactive issues/PRs.