### PR TITLE
fix: replace Snyk with OSV-Scanner

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,29 @@
+name: Security scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan-pr:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --recursive
+        ./
+
+  scan-scheduled:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-scheduled.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --recursive
+        ./

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   scan-pr:
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       scan-args: |-


### PR DESCRIPTION
## Summary

Replace Snyk (hit free tier limit) with Google's OSV-Scanner for dependency vulnerability scanning.

## Motivation

`security/snyk (magnonta) — You have used your limit of private tests` was failing on every PR with no fix short of paying for Snyk. OSV-Scanner is fully open-source, uses the OSV.dev database, and integrates with GitHub's Security tab.

## Changes

- Remove Snyk webhook from repository (done via API)
- Add `.github/workflows/security.yml` with OSV-Scanner reusable workflows
- PR scan: reports only NEW vulnerabilities introduced by the PR
- Scheduled scan: full weekly scan (Monday 06:00 UTC), results in Security > Code Scanning

## How it works

| Trigger | Behavior |
|---------|----------|
| Pull request | Diff scan — only new vulns block |
| Push to main | Full scan — results in Code Scanning tab |
| Weekly schedule | Same as push — catches new CVEs in existing deps |

## Type of change

- [x] CI / tooling
- [x] Security

## Security and privacy checklist

- [x] Safe for public repository.
- [x] No sensitive data.

## User impact

None — Snyk check disappears from PR status, replaced by OSV-Scanner.