### PR TITLE
fix: add actions:read permission for OSV-Scanner

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
     - cron: "0 6 * * 1"
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 


### PR DESCRIPTION
The OSV-Scanner reusable workflow needs `actions: read` permission. Added to the top-level permissions block.