### PR TITLE
fix: update brace-expansion 5.0.5 → 5.0.6 (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1564,9 +1564,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3211,6 +3211,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Update transitive dependency `brace-expansion` from 5.0.5 to 5.0.6 to fix medium-severity vulnerability.

## Motivation

OSV-Scanner security workflow ([run #26059261893](https://github.com/weauratech/pi-memctx/actions/runs/26059261893)) detected:

| CVE | Severity | Package | Fixed in |
|-----|----------|---------|----------|
| [GHSA-jxxr-4gwj-5jf2](https://osv.dev/GHSA-jxxr-4gwj-5jf2) | Medium (6.5) | brace-expansion | 5.0.6 |

Transitive dep path: `pi-coding-agent → minimatch → brace-expansion`.

## Type of change

- [x] Maintenance or cleanup
- [x] Security

## How to test

```bash
npm run ci
npm audit
```